### PR TITLE
Upgrade project to .NET 9

### DIFF
--- a/src/CryptoTracker/CryptoTracker.Client/CryptoTracker.Client.csproj
+++ b/src/CryptoTracker/CryptoTracker.Client/CryptoTracker.Client.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
 
 	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<NoDefaultLaunchSettingsFile>true</NoDefaultLaunchSettingsFile>

--- a/src/CryptoTracker/CryptoTracker/CryptoTracker.csproj
+++ b/src/CryptoTracker/CryptoTracker/CryptoTracker.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+  <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>ec7422a4-c6cc-42a0-b4d0-1556b863174c</UserSecretsId>


### PR DESCRIPTION
## Summary
- target .NET 9 in the server and client projects

## Testing
- `dotnet restore CryptoTracker.sln` *(fails: No route to host)*
- `dotnet build CryptoTracker.sln` *(fails: No route to host)*