### PR TITLE
Add import pages with raw data storage

### DIFF
--- a/src/CryptoTracker/CryptoTracker.Client/Pages/ImportPages/BinanceDepositPage.razor
+++ b/src/CryptoTracker/CryptoTracker.Client/Pages/ImportPages/BinanceDepositPage.razor
@@ -1,0 +1,5 @@
+@page "/import/binance-deposit"
+@using CryptoTracker.Shared
+@rendermode InteractiveAuto
+
+<ImportPageBase Title="Binance Deposit History" TEntry="BinanceDeposit" DocumentType="ImportDocumentType.BinanceDepositHistory" />

--- a/src/CryptoTracker/CryptoTracker.Client/Pages/ImportPages/BinanceTradePage.razor
+++ b/src/CryptoTracker/CryptoTracker.Client/Pages/ImportPages/BinanceTradePage.razor
@@ -1,0 +1,5 @@
+@page "/import/binance-trade"
+@using CryptoTracker.Shared
+@rendermode InteractiveAuto
+
+<ImportPageBase Title="Binance Trading History" TEntry="BinanceTrade" DocumentType="ImportDocumentType.BinanceTradingHistory" />

--- a/src/CryptoTracker/CryptoTracker.Client/Pages/ImportPages/BinanceWithdrawalPage.razor
+++ b/src/CryptoTracker/CryptoTracker.Client/Pages/ImportPages/BinanceWithdrawalPage.razor
@@ -1,0 +1,5 @@
+@page "/import/binance-withdrawal"
+@using CryptoTracker.Shared
+@rendermode InteractiveAuto
+
+<ImportPageBase Title="Binance Withdrawal History" TEntry="BinanceWithdrawal" DocumentType="ImportDocumentType.BinanceWithdrawalHistory" />

--- a/src/CryptoTracker/CryptoTracker.Client/Pages/ImportPages/BitcoinDeTransactionsPage.razor
+++ b/src/CryptoTracker/CryptoTracker.Client/Pages/ImportPages/BitcoinDeTransactionsPage.razor
@@ -1,0 +1,5 @@
+@page "/import/bitcoinde-transactions"
+@using CryptoTracker.Shared
+@rendermode InteractiveAuto
+
+<ImportPageBase Title="Bitcoin.de Transactions" TEntry="BitcoinDeTransaction" DocumentType="ImportDocumentType.BitcoinDeTransactions" />

--- a/src/CryptoTracker/CryptoTracker.Client/Pages/ImportPages/BitpandaTransactionsPage.razor
+++ b/src/CryptoTracker/CryptoTracker.Client/Pages/ImportPages/BitpandaTransactionsPage.razor
@@ -1,0 +1,5 @@
+@page "/import/bitpanda-transactions"
+@using CryptoTracker.Shared
+@rendermode InteractiveAuto
+
+<ImportPageBase Title="Bitpanda Transactions" TEntry="BitpandaTransaction" DocumentType="ImportDocumentType.BitpandaTransaction" />

--- a/src/CryptoTracker/CryptoTracker.Client/Pages/ImportPages/ImportPageBase.razor
+++ b/src/CryptoTracker/CryptoTracker.Client/Pages/ImportPages/ImportPageBase.razor
@@ -1,0 +1,94 @@
+@using Microsoft.AspNetCore.Components.Forms
+@using System.Net.Http.Headers
+@using System.Net.Http.Json
+@using CryptoTracker.Shared
+@using System.Text.Json
+
+<h3>@Title</h3>
+
+<InputFile OnChange="HandleFileSelected" />
+<DxTextBox @bind-Text="WalletName" NullText="Wallet Name" />
+<button class="btn btn-primary mt-2" @onclick="Upload">Importieren</button>
+
+@if (Entries == null)
+{
+    <p>Loading...</p>
+}
+else if (Entries.Count > 0)
+{
+    var headers = Entries[0].EnumerateObject().Select(p => p.Name).Where(n => n != "Id").ToList();
+    <table class="table table-sm">
+        <thead>
+            <tr>
+                @foreach (var h in headers)
+                {
+                    <th>@h</th>
+                }
+            </tr>
+        </thead>
+        <tbody>
+            @foreach (var entry in Entries)
+            {
+                <tr>
+                    @foreach (var h in headers)
+                    {
+                        <td>@entry.GetProperty(h).ToString()</td>
+                    }
+                </tr>
+            }
+        </tbody>
+    </table>
+}
+
+@if (ErrorMessage != null)
+{
+    <div class="alert alert-danger" role="alert">@ErrorMessage</div>
+}
+
+@code {
+    [Parameter] public string Title { get; set; } = string.Empty;
+
+    [Inject] private HttpClient HttpClient { get; set; } = default!;
+
+    private IList<JsonElement>? Entries;
+    private IBrowserFile? SelectedFile;
+    private string WalletName { get; set; } = string.Empty;
+    private string? ErrorMessage { get; set; }
+    private const long MAX_REQUEST_SIZE = 1024 * 1024 * 100;
+
+    [Parameter] public ImportDocumentType DocumentType { get; set; }
+
+    protected override async Task OnInitializedAsync()
+    {
+        await base.OnInitializedAsync();
+        await LoadData();
+    }
+
+    private async Task HandleFileSelected(InputFileChangeEventArgs e)
+    {
+        SelectedFile = e.File;
+    }
+
+    private async Task Upload()
+    {
+        if (SelectedFile != null)
+        {
+            using var content = new MultipartFormDataContent();
+            using var fileContent = new StreamContent(SelectedFile.OpenReadStream(MAX_REQUEST_SIZE));
+            fileContent.Headers.ContentType = new MediaTypeHeaderValue(SelectedFile.ContentType);
+            content.Add(fileContent, "\"file\"", SelectedFile.Name);
+            content.Add(JsonContent.Create(new ImportFileRequest() { Type = DocumentType, WalletName = WalletName }), "request");
+            var response = await HttpClient.PostAsync("api/DataImport/ImportFile", content);
+            if (!response.IsSuccessStatusCode)
+                ErrorMessage = await response.Content.ReadAsStringAsync();
+            SelectedFile = null;
+            WalletName = string.Empty;
+            await LoadData();
+        }
+    }
+
+    private async Task LoadData()
+    {
+        Entries = await HttpClient.GetFromJsonAsync<IList<JsonElement>>($"api/ImportEntries/GetEntries?type={DocumentType}");
+    }
+}

--- a/src/CryptoTracker/CryptoTracker.Client/Pages/ImportPages/MetamaskTradesPage.razor
+++ b/src/CryptoTracker/CryptoTracker.Client/Pages/ImportPages/MetamaskTradesPage.razor
@@ -1,0 +1,5 @@
+@page "/import/metamask-trades"
+@using CryptoTracker.Shared
+@rendermode InteractiveAuto
+
+<ImportPageBase Title="Metamask Trading History" TEntry="MetamaskTrade" DocumentType="ImportDocumentType.MetamaskTradingHistory" />

--- a/src/CryptoTracker/CryptoTracker.Client/Pages/ImportPages/MetamaskTransactionsPage.razor
+++ b/src/CryptoTracker/CryptoTracker.Client/Pages/ImportPages/MetamaskTransactionsPage.razor
@@ -1,0 +1,5 @@
+@page "/import/metamask-transactions"
+@using CryptoTracker.Shared
+@rendermode InteractiveAuto
+
+<ImportPageBase Title="Metamask Transactions" TEntry="MetamaskTransaction" DocumentType="ImportDocumentType.MetamaskTransactions" />

--- a/src/CryptoTracker/CryptoTracker.Client/Pages/ImportPages/OkxDepositPage.razor
+++ b/src/CryptoTracker/CryptoTracker.Client/Pages/ImportPages/OkxDepositPage.razor
@@ -1,0 +1,5 @@
+@page "/import/okx-deposit"
+@using CryptoTracker.Shared
+@rendermode InteractiveAuto
+
+<ImportPageBase Title="Okx Deposit History" TEntry="OkxDeposit" DocumentType="ImportDocumentType.OkxDepositHistory" />

--- a/src/CryptoTracker/CryptoTracker.Client/Pages/ImportPages/OkxTradePage.razor
+++ b/src/CryptoTracker/CryptoTracker.Client/Pages/ImportPages/OkxTradePage.razor
@@ -1,0 +1,5 @@
+@page "/import/okx-trade"
+@using CryptoTracker.Shared
+@rendermode InteractiveAuto
+
+<ImportPageBase Title="Okx Trading History" TEntry="OkxTrade" DocumentType="ImportDocumentType.OkxTradingHistory" />

--- a/src/CryptoTracker/CryptoTracker/Components/Layout/NavMenu.razor
+++ b/src/CryptoTracker/CryptoTracker/Components/Layout/NavMenu.razor
@@ -19,6 +19,51 @@
                 <span class="bi bi-plus-square-fill-nav-menu" aria-hidden="true"></span> Import
             </NavLink>
         </div>
+        <div class="nav-item px-3">
+            <NavLink class="nav-link" href="import/binance-deposit">
+                <span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> Binance Deposit
+            </NavLink>
+        </div>
+        <div class="nav-item px-3">
+            <NavLink class="nav-link" href="import/binance-withdrawal">
+                <span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> Binance Withdrawal
+            </NavLink>
+        </div>
+        <div class="nav-item px-3">
+            <NavLink class="nav-link" href="import/binance-trade">
+                <span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> Binance Trade
+            </NavLink>
+        </div>
+        <div class="nav-item px-3">
+            <NavLink class="nav-link" href="import/bitcoinde-transactions">
+                <span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> Bitcoin.de Transactions
+            </NavLink>
+        </div>
+        <div class="nav-item px-3">
+            <NavLink class="nav-link" href="import/bitpanda-transactions">
+                <span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> Bitpanda Transactions
+            </NavLink>
+        </div>
+        <div class="nav-item px-3">
+            <NavLink class="nav-link" href="import/metamask-transactions">
+                <span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> Metamask Transactions
+            </NavLink>
+        </div>
+        <div class="nav-item px-3">
+            <NavLink class="nav-link" href="import/metamask-trades">
+                <span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> Metamask Trades
+            </NavLink>
+        </div>
+        <div class="nav-item px-3">
+            <NavLink class="nav-link" href="import/okx-deposit">
+                <span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> Okx Deposit
+            </NavLink>
+        </div>
+        <div class="nav-item px-3">
+            <NavLink class="nav-link" href="import/okx-trade">
+                <span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> Okx Trade
+            </NavLink>
+        </div>
     </nav>
 </div>
 

--- a/src/CryptoTracker/CryptoTracker/Controllers/ImportEntriesController.cs
+++ b/src/CryptoTracker/CryptoTracker/Controllers/ImportEntriesController.cs
@@ -1,0 +1,38 @@
+using CryptoTracker.Import.Objects;
+using CryptoTracker.Shared;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace CryptoTracker.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class ImportEntriesController : ControllerBase
+{
+    private readonly CryptoTrackerDbContext _dbContext;
+
+    public ImportEntriesController(CryptoTrackerDbContext dbContext)
+    {
+        _dbContext = dbContext;
+    }
+
+    [HttpGet("GetEntries")]
+    public async Task<IActionResult> GetEntries(ImportDocumentType type)
+    {
+        object result = type switch
+        {
+            ImportDocumentType.BinanceDepositHistory => await _dbContext.BinanceDeposits.ToListAsync(),
+            ImportDocumentType.BinanceWithdrawalHistory => await _dbContext.BinanceWithdrawals.ToListAsync(),
+            ImportDocumentType.BinanceTradingHistory => await _dbContext.BinanceTrades.ToListAsync(),
+            ImportDocumentType.BitcoinDeTransactions => await _dbContext.BitcoinDeTransactions.ToListAsync(),
+            ImportDocumentType.BitpandaTransaction => await _dbContext.BitpandaTransactions.ToListAsync(),
+            ImportDocumentType.MetamaskTradingHistory => await _dbContext.MetamaskTrades.ToListAsync(),
+            ImportDocumentType.MetamaskTransactions => await _dbContext.MetamaskTransactions.ToListAsync(),
+            ImportDocumentType.OkxDepositHistory => await _dbContext.OkxDeposits.ToListAsync(),
+            ImportDocumentType.OkxTradingHistory => await _dbContext.OkxTrades.ToListAsync(),
+            _ => new List<object>()
+        };
+
+        return Ok(result);
+    }
+}

--- a/src/CryptoTracker/CryptoTracker/DbContext/CryptoTrackerDbContext.cs
+++ b/src/CryptoTracker/CryptoTracker/DbContext/CryptoTrackerDbContext.cs
@@ -1,4 +1,5 @@
 ﻿using CryptoTracker.Entities;
+using CryptoTracker.Import.Objects;
 using Microsoft.EntityFrameworkCore;
 
 namespace CryptoTracker
@@ -7,6 +8,15 @@ namespace CryptoTracker
     {
         public DbSet<CryptoTransaction> CryptoTransactions { get; set; }
         public DbSet<CryptoTrade> CryptoTrades { get; set; }
+        public DbSet<BinanceDeposit> BinanceDeposits { get; set; }
+        public DbSet<BinanceWithdrawal> BinanceWithdrawals { get; set; }
+        public DbSet<BinanceTrade> BinanceTrades { get; set; }
+        public DbSet<BitcoinDeTransaction> BitcoinDeTransactions { get; set; }
+        public DbSet<BitpandaTransaction> BitpandaTransactions { get; set; }
+        public DbSet<MetamaskTrade> MetamaskTrades { get; set; }
+        public DbSet<MetamaskTransaction> MetamaskTransactions { get; set; }
+        public DbSet<OkxDeposit> OkxDeposits { get; set; }
+        public DbSet<OkxTrade> OkxTrades { get; set; }
 
         public CryptoTrackerDbContext(DbContextOptions<CryptoTrackerDbContext> options) : base(options)
         {
@@ -27,6 +37,16 @@ namespace CryptoTracker
                 .WithOne()
                 .HasForeignKey<CryptoTrade>(c => c.OppositeTradeId)
                 .OnDelete(DeleteBehavior.Restrict);
+
+            modelBuilder.Entity<BinanceDeposit>().HasKey(b => b.Id);
+            modelBuilder.Entity<BinanceWithdrawal>().HasKey(b => b.Id);
+            modelBuilder.Entity<BinanceTrade>().HasKey(b => b.Id);
+            modelBuilder.Entity<BitcoinDeTransaction>().HasKey(b => b.Id);
+            modelBuilder.Entity<BitpandaTransaction>().HasKey(b => b.Id);
+            modelBuilder.Entity<MetamaskTrade>().HasKey(b => b.Id);
+            modelBuilder.Entity<MetamaskTransaction>().HasKey(b => b.Id);
+            modelBuilder.Entity<OkxDeposit>().HasKey(b => b.Id);
+            modelBuilder.Entity<OkxTrade>().HasKey(b => b.Id);
 
             modelBuilder.Entity<CryptoTrade>()
                 .Property(c => c.Price)

--- a/src/CryptoTracker/CryptoTracker/Import/Objects/BinanceDeposit.cs
+++ b/src/CryptoTracker/CryptoTracker/Import/Objects/BinanceDeposit.cs
@@ -9,6 +9,7 @@ namespace CryptoTracker.Import.Objects
     
     public class BinanceDeposit : ICryptoCsvEntry
     {
+        public int Id { get; set; }
         [Name("Date(UTC)")]
         public DateTimeOffset Date { get; set; }
 

--- a/src/CryptoTracker/CryptoTracker/Import/Objects/BinanceTrade.cs
+++ b/src/CryptoTracker/CryptoTracker/Import/Objects/BinanceTrade.cs
@@ -9,6 +9,7 @@ namespace CryptoTracker.Import.Objects
 
     public class BinanceTrade : ICryptoCsvEntry
     {
+        public int Id { get; set; }
         [Name("Date(UTC)")]
         public DateTimeOffset Date { get; set; }
 

--- a/src/CryptoTracker/CryptoTracker/Import/Objects/BinanceWithdrawal.cs
+++ b/src/CryptoTracker/CryptoTracker/Import/Objects/BinanceWithdrawal.cs
@@ -9,6 +9,7 @@ namespace CryptoTracker.Import.Objects
 
     public class BinanceWithdrawal : ICryptoCsvEntry
     {
+        public int Id { get; set; }
         [Name("Date(UTC)")]
         public DateTimeOffset Date { get; set; }
 

--- a/src/CryptoTracker/CryptoTracker/Import/Objects/BitcoinDeTransaction.cs
+++ b/src/CryptoTracker/CryptoTracker/Import/Objects/BitcoinDeTransaction.cs
@@ -11,6 +11,7 @@ namespace CryptoTracker.Import.Objects
 
     public class BitcoinDeTransaction : ICryptoCsvEntry
     {
+        public int Id { get; set; }
         public DateTime Datum { get; set; }
 
         /// <summary>

--- a/src/CryptoTracker/CryptoTracker/Import/Objects/BitpandaTransaction.cs
+++ b/src/CryptoTracker/CryptoTracker/Import/Objects/BitpandaTransaction.cs
@@ -13,6 +13,7 @@ namespace CryptoTracker.Import.Objects
 
     public class BitpandaTransaction : ICryptoCsvEntry
     {
+        public int Id { get; set; }
         /// <summary>
         /// Interne TransactionId
         /// </summary>

--- a/src/CryptoTracker/CryptoTracker/Import/Objects/MetamaskTrade.cs
+++ b/src/CryptoTracker/CryptoTracker/Import/Objects/MetamaskTrade.cs
@@ -9,6 +9,7 @@ namespace CryptoTracker.Import.Objects
 
     public class MetamaskTrade : ICryptoCsvEntry
     {
+        public int Id { get; set; }
         [Name("Date(UTC)")]
         public DateTimeOffset Date { get; set; }
 

--- a/src/CryptoTracker/CryptoTracker/Import/Objects/MetamaskTransaction.cs
+++ b/src/CryptoTracker/CryptoTracker/Import/Objects/MetamaskTransaction.cs
@@ -10,6 +10,7 @@ namespace CryptoTracker.Import.Objects
 
     public class MetamaskTransaction : ICryptoCsvEntry
     {
+        public int Id { get; set; }
         /// <summary>
         /// Datum in ISO 8601 und CET
         /// </summary>

--- a/src/CryptoTracker/CryptoTracker/Import/Objects/OkxDeposit.cs
+++ b/src/CryptoTracker/CryptoTracker/Import/Objects/OkxDeposit.cs
@@ -9,6 +9,7 @@ namespace CryptoTracker.Import.Objects
 
     public class OkxDeposit : ICryptoCsvEntry
     {
+        public int Id { get; set; }
         [Name("Date(UTC)")]
         public DateTimeOffset Date { get; set; }
 

--- a/src/CryptoTracker/CryptoTracker/Import/Objects/OkxTrade.cs
+++ b/src/CryptoTracker/CryptoTracker/Import/Objects/OkxTrade.cs
@@ -9,6 +9,7 @@ namespace CryptoTracker.Import.Objects
 
     public class OkxTrade : ICryptoCsvEntry
     {
+        public int Id { get; set; }
         [Name("Date(UTC)")]
         public DateTimeOffset Date { get; set; }
 


### PR DESCRIPTION
## Summary
- store imported csv entries in database
- provide endpoints to fetch raw import entries
- add Blazor pages for each import type
- extend navigation with links to new pages
- show imported data in simple tables

## Testing
- `dotnet build CryptoTracker.sln`