### PR TITLE
Add import tests

### DIFF
--- a/CryptoTracker.sln
+++ b/CryptoTracker.sln
@@ -7,23 +7,62 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CryptoTracker", "src\Crypto
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CryptoTracker.Client", "src\CryptoTracker\CryptoTracker.Client\CryptoTracker.Client.csproj", "{3178B75F-AE76-4EFA-AADA-20CAEB8A27BA}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{0AB3BF05-4346-4AA6-1389-037BE0695223}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CryptoTracker.Tests", "tests\CryptoTracker.Tests\CryptoTracker.Tests.csproj", "{5B1D2DA3-3D91-4E3F-9563-F23B29D98E0E}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{3F1AADFA-7DBE-4C78-BDE8-DAF7BC851194}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{3F1AADFA-7DBE-4C78-BDE8-DAF7BC851194}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3F1AADFA-7DBE-4C78-BDE8-DAF7BC851194}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{3F1AADFA-7DBE-4C78-BDE8-DAF7BC851194}.Debug|x64.Build.0 = Debug|Any CPU
+		{3F1AADFA-7DBE-4C78-BDE8-DAF7BC851194}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{3F1AADFA-7DBE-4C78-BDE8-DAF7BC851194}.Debug|x86.Build.0 = Debug|Any CPU
 		{3F1AADFA-7DBE-4C78-BDE8-DAF7BC851194}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{3F1AADFA-7DBE-4C78-BDE8-DAF7BC851194}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3F1AADFA-7DBE-4C78-BDE8-DAF7BC851194}.Release|x64.ActiveCfg = Release|Any CPU
+		{3F1AADFA-7DBE-4C78-BDE8-DAF7BC851194}.Release|x64.Build.0 = Release|Any CPU
+		{3F1AADFA-7DBE-4C78-BDE8-DAF7BC851194}.Release|x86.ActiveCfg = Release|Any CPU
+		{3F1AADFA-7DBE-4C78-BDE8-DAF7BC851194}.Release|x86.Build.0 = Release|Any CPU
 		{3178B75F-AE76-4EFA-AADA-20CAEB8A27BA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{3178B75F-AE76-4EFA-AADA-20CAEB8A27BA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3178B75F-AE76-4EFA-AADA-20CAEB8A27BA}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{3178B75F-AE76-4EFA-AADA-20CAEB8A27BA}.Debug|x64.Build.0 = Debug|Any CPU
+		{3178B75F-AE76-4EFA-AADA-20CAEB8A27BA}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{3178B75F-AE76-4EFA-AADA-20CAEB8A27BA}.Debug|x86.Build.0 = Debug|Any CPU
 		{3178B75F-AE76-4EFA-AADA-20CAEB8A27BA}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{3178B75F-AE76-4EFA-AADA-20CAEB8A27BA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3178B75F-AE76-4EFA-AADA-20CAEB8A27BA}.Release|x64.ActiveCfg = Release|Any CPU
+		{3178B75F-AE76-4EFA-AADA-20CAEB8A27BA}.Release|x64.Build.0 = Release|Any CPU
+		{3178B75F-AE76-4EFA-AADA-20CAEB8A27BA}.Release|x86.ActiveCfg = Release|Any CPU
+		{3178B75F-AE76-4EFA-AADA-20CAEB8A27BA}.Release|x86.Build.0 = Release|Any CPU
+		{5B1D2DA3-3D91-4E3F-9563-F23B29D98E0E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5B1D2DA3-3D91-4E3F-9563-F23B29D98E0E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5B1D2DA3-3D91-4E3F-9563-F23B29D98E0E}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{5B1D2DA3-3D91-4E3F-9563-F23B29D98E0E}.Debug|x64.Build.0 = Debug|Any CPU
+		{5B1D2DA3-3D91-4E3F-9563-F23B29D98E0E}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{5B1D2DA3-3D91-4E3F-9563-F23B29D98E0E}.Debug|x86.Build.0 = Debug|Any CPU
+		{5B1D2DA3-3D91-4E3F-9563-F23B29D98E0E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5B1D2DA3-3D91-4E3F-9563-F23B29D98E0E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5B1D2DA3-3D91-4E3F-9563-F23B29D98E0E}.Release|x64.ActiveCfg = Release|Any CPU
+		{5B1D2DA3-3D91-4E3F-9563-F23B29D98E0E}.Release|x64.Build.0 = Release|Any CPU
+		{5B1D2DA3-3D91-4E3F-9563-F23B29D98E0E}.Release|x86.ActiveCfg = Release|Any CPU
+		{5B1D2DA3-3D91-4E3F-9563-F23B29D98E0E}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{5B1D2DA3-3D91-4E3F-9563-F23B29D98E0E} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {BD4BDA01-3DBD-424D-919E-70B636415A0F}

--- a/src/CryptoTracker/CryptoTracker.Client/Pages/ImportPages/BinanceDepositPage.razor
+++ b/src/CryptoTracker/CryptoTracker.Client/Pages/ImportPages/BinanceDepositPage.razor
@@ -1,0 +1,5 @@
+@page "/import/binance-deposit"
+@using CryptoTracker.Shared
+@rendermode InteractiveAuto
+
+<ImportPageBase Title="Binance Deposit History" TEntry="BinanceDeposit" DocumentType="ImportDocumentType.BinanceDepositHistory" />

--- a/src/CryptoTracker/CryptoTracker.Client/Pages/ImportPages/BinanceTradePage.razor
+++ b/src/CryptoTracker/CryptoTracker.Client/Pages/ImportPages/BinanceTradePage.razor
@@ -1,0 +1,5 @@
+@page "/import/binance-trade"
+@using CryptoTracker.Shared
+@rendermode InteractiveAuto
+
+<ImportPageBase Title="Binance Trading History" TEntry="BinanceTrade" DocumentType="ImportDocumentType.BinanceTradingHistory" />

--- a/src/CryptoTracker/CryptoTracker.Client/Pages/ImportPages/BinanceWithdrawalPage.razor
+++ b/src/CryptoTracker/CryptoTracker.Client/Pages/ImportPages/BinanceWithdrawalPage.razor
@@ -1,0 +1,5 @@
+@page "/import/binance-withdrawal"
+@using CryptoTracker.Shared
+@rendermode InteractiveAuto
+
+<ImportPageBase Title="Binance Withdrawal History" TEntry="BinanceWithdrawal" DocumentType="ImportDocumentType.BinanceWithdrawalHistory" />

--- a/src/CryptoTracker/CryptoTracker.Client/Pages/ImportPages/BitcoinDeTransactionsPage.razor
+++ b/src/CryptoTracker/CryptoTracker.Client/Pages/ImportPages/BitcoinDeTransactionsPage.razor
@@ -1,0 +1,5 @@
+@page "/import/bitcoinde-transactions"
+@using CryptoTracker.Shared
+@rendermode InteractiveAuto
+
+<ImportPageBase Title="Bitcoin.de Transactions" TEntry="BitcoinDeTransaction" DocumentType="ImportDocumentType.BitcoinDeTransactions" />

--- a/src/CryptoTracker/CryptoTracker.Client/Pages/ImportPages/BitpandaTransactionsPage.razor
+++ b/src/CryptoTracker/CryptoTracker.Client/Pages/ImportPages/BitpandaTransactionsPage.razor
@@ -1,0 +1,5 @@
+@page "/import/bitpanda-transactions"
+@using CryptoTracker.Shared
+@rendermode InteractiveAuto
+
+<ImportPageBase Title="Bitpanda Transactions" TEntry="BitpandaTransaction" DocumentType="ImportDocumentType.BitpandaTransaction" />

--- a/src/CryptoTracker/CryptoTracker.Client/Pages/ImportPages/ImportPageBase.razor
+++ b/src/CryptoTracker/CryptoTracker.Client/Pages/ImportPages/ImportPageBase.razor
@@ -1,0 +1,94 @@
+@using Microsoft.AspNetCore.Components.Forms
+@using System.Net.Http.Headers
+@using System.Net.Http.Json
+@using CryptoTracker.Shared
+@using System.Text.Json
+
+<h3>@Title</h3>
+
+<InputFile OnChange="HandleFileSelected" />
+<DxTextBox @bind-Text="WalletName" NullText="Wallet Name" />
+<button class="btn btn-primary mt-2" @onclick="Upload">Importieren</button>
+
+@if (Entries == null)
+{
+    <p>Loading...</p>
+}
+else if (Entries.Count > 0)
+{
+    var headers = Entries[0].EnumerateObject().Select(p => p.Name).Where(n => n != "Id").ToList();
+    <table class="table table-sm">
+        <thead>
+            <tr>
+                @foreach (var h in headers)
+                {
+                    <th>@h</th>
+                }
+            </tr>
+        </thead>
+        <tbody>
+            @foreach (var entry in Entries)
+            {
+                <tr>
+                    @foreach (var h in headers)
+                    {
+                        <td>@entry.GetProperty(h).ToString()</td>
+                    }
+                </tr>
+            }
+        </tbody>
+    </table>
+}
+
+@if (ErrorMessage != null)
+{
+    <div class="alert alert-danger" role="alert">@ErrorMessage</div>
+}
+
+@code {
+    [Parameter] public string Title { get; set; } = string.Empty;
+
+    [Inject] private HttpClient HttpClient { get; set; } = default!;
+
+    private IList<JsonElement>? Entries;
+    private IBrowserFile? SelectedFile;
+    private string WalletName { get; set; } = string.Empty;
+    private string? ErrorMessage { get; set; }
+    private const long MAX_REQUEST_SIZE = 1024 * 1024 * 100;
+
+    [Parameter] public ImportDocumentType DocumentType { get; set; }
+
+    protected override async Task OnInitializedAsync()
+    {
+        await base.OnInitializedAsync();
+        await LoadData();
+    }
+
+    private async Task HandleFileSelected(InputFileChangeEventArgs e)
+    {
+        SelectedFile = e.File;
+    }
+
+    private async Task Upload()
+    {
+        if (SelectedFile != null)
+        {
+            using var content = new MultipartFormDataContent();
+            using var fileContent = new StreamContent(SelectedFile.OpenReadStream(MAX_REQUEST_SIZE));
+            fileContent.Headers.ContentType = new MediaTypeHeaderValue(SelectedFile.ContentType);
+            content.Add(fileContent, "\"file\"", SelectedFile.Name);
+            content.Add(JsonContent.Create(new ImportFileRequest() { Type = DocumentType, WalletName = WalletName }), "request");
+            var response = await HttpClient.PostAsync("api/DataImport/ImportFile", content);
+            if (!response.IsSuccessStatusCode)
+                ErrorMessage = await response.Content.ReadAsStringAsync();
+            SelectedFile = null;
+            WalletName = string.Empty;
+            await LoadData();
+        }
+    }
+
+    private async Task LoadData()
+    {
+        Entries = await HttpClient.GetFromJsonAsync<IList<JsonElement>>($"api/ImportEntries/GetEntries?type={DocumentType}");
+    }
+}

--- a/src/CryptoTracker/CryptoTracker.Client/Pages/ImportPages/MetamaskTradesPage.razor
+++ b/src/CryptoTracker/CryptoTracker.Client/Pages/ImportPages/MetamaskTradesPage.razor
@@ -1,0 +1,5 @@
+@page "/import/metamask-trades"
+@using CryptoTracker.Shared
+@rendermode InteractiveAuto
+
+<ImportPageBase Title="Metamask Trading History" TEntry="MetamaskTrade" DocumentType="ImportDocumentType.MetamaskTradingHistory" />

--- a/src/CryptoTracker/CryptoTracker.Client/Pages/ImportPages/MetamaskTransactionsPage.razor
+++ b/src/CryptoTracker/CryptoTracker.Client/Pages/ImportPages/MetamaskTransactionsPage.razor
@@ -1,0 +1,5 @@
+@page "/import/metamask-transactions"
+@using CryptoTracker.Shared
+@rendermode InteractiveAuto
+
+<ImportPageBase Title="Metamask Transactions" TEntry="MetamaskTransaction" DocumentType="ImportDocumentType.MetamaskTransactions" />

--- a/src/CryptoTracker/CryptoTracker.Client/Pages/ImportPages/OkxDepositPage.razor
+++ b/src/CryptoTracker/CryptoTracker.Client/Pages/ImportPages/OkxDepositPage.razor
@@ -1,0 +1,5 @@
+@page "/import/okx-deposit"
+@using CryptoTracker.Shared
+@rendermode InteractiveAuto
+
+<ImportPageBase Title="Okx Deposit History" TEntry="OkxDeposit" DocumentType="ImportDocumentType.OkxDepositHistory" />

--- a/src/CryptoTracker/CryptoTracker.Client/Pages/ImportPages/OkxTradePage.razor
+++ b/src/CryptoTracker/CryptoTracker.Client/Pages/ImportPages/OkxTradePage.razor
@@ -1,0 +1,5 @@
+@page "/import/okx-trade"
+@using CryptoTracker.Shared
+@rendermode InteractiveAuto
+
+<ImportPageBase Title="Okx Trading History" TEntry="OkxTrade" DocumentType="ImportDocumentType.OkxTradingHistory" />

--- a/src/CryptoTracker/CryptoTracker/Components/Layout/NavMenu.razor
+++ b/src/CryptoTracker/CryptoTracker/Components/Layout/NavMenu.razor
@@ -19,6 +19,51 @@
                 <span class="bi bi-plus-square-fill-nav-menu" aria-hidden="true"></span> Import
             </NavLink>
         </div>
+        <div class="nav-item px-3">
+            <NavLink class="nav-link" href="import/binance-deposit">
+                <span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> Binance Deposit
+            </NavLink>
+        </div>
+        <div class="nav-item px-3">
+            <NavLink class="nav-link" href="import/binance-withdrawal">
+                <span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> Binance Withdrawal
+            </NavLink>
+        </div>
+        <div class="nav-item px-3">
+            <NavLink class="nav-link" href="import/binance-trade">
+                <span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> Binance Trade
+            </NavLink>
+        </div>
+        <div class="nav-item px-3">
+            <NavLink class="nav-link" href="import/bitcoinde-transactions">
+                <span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> Bitcoin.de Transactions
+            </NavLink>
+        </div>
+        <div class="nav-item px-3">
+            <NavLink class="nav-link" href="import/bitpanda-transactions">
+                <span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> Bitpanda Transactions
+            </NavLink>
+        </div>
+        <div class="nav-item px-3">
+            <NavLink class="nav-link" href="import/metamask-transactions">
+                <span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> Metamask Transactions
+            </NavLink>
+        </div>
+        <div class="nav-item px-3">
+            <NavLink class="nav-link" href="import/metamask-trades">
+                <span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> Metamask Trades
+            </NavLink>
+        </div>
+        <div class="nav-item px-3">
+            <NavLink class="nav-link" href="import/okx-deposit">
+                <span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> Okx Deposit
+            </NavLink>
+        </div>
+        <div class="nav-item px-3">
+            <NavLink class="nav-link" href="import/okx-trade">
+                <span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> Okx Trade
+            </NavLink>
+        </div>
     </nav>
 </div>
 

--- a/src/CryptoTracker/CryptoTracker/Controllers/ImportEntriesController.cs
+++ b/src/CryptoTracker/CryptoTracker/Controllers/ImportEntriesController.cs
@@ -1,0 +1,38 @@
+using CryptoTracker.Import.Objects;
+using CryptoTracker.Shared;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace CryptoTracker.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class ImportEntriesController : ControllerBase
+{
+    private readonly CryptoTrackerDbContext _dbContext;
+
+    public ImportEntriesController(CryptoTrackerDbContext dbContext)
+    {
+        _dbContext = dbContext;
+    }
+
+    [HttpGet("GetEntries")]
+    public async Task<IActionResult> GetEntries(ImportDocumentType type)
+    {
+        object result = type switch
+        {
+            ImportDocumentType.BinanceDepositHistory => await _dbContext.BinanceDeposits.ToListAsync(),
+            ImportDocumentType.BinanceWithdrawalHistory => await _dbContext.BinanceWithdrawals.ToListAsync(),
+            ImportDocumentType.BinanceTradingHistory => await _dbContext.BinanceTrades.ToListAsync(),
+            ImportDocumentType.BitcoinDeTransactions => await _dbContext.BitcoinDeTransactions.ToListAsync(),
+            ImportDocumentType.BitpandaTransaction => await _dbContext.BitpandaTransactions.ToListAsync(),
+            ImportDocumentType.MetamaskTradingHistory => await _dbContext.MetamaskTrades.ToListAsync(),
+            ImportDocumentType.MetamaskTransactions => await _dbContext.MetamaskTransactions.ToListAsync(),
+            ImportDocumentType.OkxDepositHistory => await _dbContext.OkxDeposits.ToListAsync(),
+            ImportDocumentType.OkxTradingHistory => await _dbContext.OkxTrades.ToListAsync(),
+            _ => new List<object>()
+        };
+
+        return Ok(result);
+    }
+}

--- a/src/CryptoTracker/CryptoTracker/DbContext/CryptoTrackerDbContext.cs
+++ b/src/CryptoTracker/CryptoTracker/DbContext/CryptoTrackerDbContext.cs
@@ -1,4 +1,5 @@
 ﻿using CryptoTracker.Entities;
+using CryptoTracker.Import.Objects;
 using Microsoft.EntityFrameworkCore;
 
 namespace CryptoTracker
@@ -7,6 +8,15 @@ namespace CryptoTracker
     {
         public DbSet<CryptoTransaction> CryptoTransactions { get; set; }
         public DbSet<CryptoTrade> CryptoTrades { get; set; }
+        public DbSet<BinanceDeposit> BinanceDeposits { get; set; }
+        public DbSet<BinanceWithdrawal> BinanceWithdrawals { get; set; }
+        public DbSet<BinanceTrade> BinanceTrades { get; set; }
+        public DbSet<BitcoinDeTransaction> BitcoinDeTransactions { get; set; }
+        public DbSet<BitpandaTransaction> BitpandaTransactions { get; set; }
+        public DbSet<MetamaskTrade> MetamaskTrades { get; set; }
+        public DbSet<MetamaskTransaction> MetamaskTransactions { get; set; }
+        public DbSet<OkxDeposit> OkxDeposits { get; set; }
+        public DbSet<OkxTrade> OkxTrades { get; set; }
 
         public CryptoTrackerDbContext(DbContextOptions<CryptoTrackerDbContext> options) : base(options)
         {
@@ -27,6 +37,16 @@ namespace CryptoTracker
                 .WithOne()
                 .HasForeignKey<CryptoTrade>(c => c.OppositeTradeId)
                 .OnDelete(DeleteBehavior.Restrict);
+
+            modelBuilder.Entity<BinanceDeposit>().HasKey(b => b.Id);
+            modelBuilder.Entity<BinanceWithdrawal>().HasKey(b => b.Id);
+            modelBuilder.Entity<BinanceTrade>().HasKey(b => b.Id);
+            modelBuilder.Entity<BitcoinDeTransaction>().HasKey(b => b.Id);
+            modelBuilder.Entity<BitpandaTransaction>().HasKey(b => b.Id);
+            modelBuilder.Entity<MetamaskTrade>().HasKey(b => b.Id);
+            modelBuilder.Entity<MetamaskTransaction>().HasKey(b => b.Id);
+            modelBuilder.Entity<OkxDeposit>().HasKey(b => b.Id);
+            modelBuilder.Entity<OkxTrade>().HasKey(b => b.Id);
 
             modelBuilder.Entity<CryptoTrade>()
                 .Property(c => c.Price)

--- a/src/CryptoTracker/CryptoTracker/Import/Objects/BinanceDeposit.cs
+++ b/src/CryptoTracker/CryptoTracker/Import/Objects/BinanceDeposit.cs
@@ -9,6 +9,7 @@ namespace CryptoTracker.Import.Objects
     
     public class BinanceDeposit : ICryptoCsvEntry
     {
+        public int Id { get; set; }
         [Name("Date(UTC)")]
         public DateTimeOffset Date { get; set; }
 

--- a/src/CryptoTracker/CryptoTracker/Import/Objects/BinanceTrade.cs
+++ b/src/CryptoTracker/CryptoTracker/Import/Objects/BinanceTrade.cs
@@ -9,6 +9,7 @@ namespace CryptoTracker.Import.Objects
 
     public class BinanceTrade : ICryptoCsvEntry
     {
+        public int Id { get; set; }
         [Name("Date(UTC)")]
         public DateTimeOffset Date { get; set; }
 

--- a/src/CryptoTracker/CryptoTracker/Import/Objects/BinanceWithdrawal.cs
+++ b/src/CryptoTracker/CryptoTracker/Import/Objects/BinanceWithdrawal.cs
@@ -9,6 +9,7 @@ namespace CryptoTracker.Import.Objects
 
     public class BinanceWithdrawal : ICryptoCsvEntry
     {
+        public int Id { get; set; }
         [Name("Date(UTC)")]
         public DateTimeOffset Date { get; set; }
 

--- a/src/CryptoTracker/CryptoTracker/Import/Objects/BitcoinDeTransaction.cs
+++ b/src/CryptoTracker/CryptoTracker/Import/Objects/BitcoinDeTransaction.cs
@@ -11,6 +11,7 @@ namespace CryptoTracker.Import.Objects
 
     public class BitcoinDeTransaction : ICryptoCsvEntry
     {
+        public int Id { get; set; }
         public DateTime Datum { get; set; }
 
         /// <summary>

--- a/src/CryptoTracker/CryptoTracker/Import/Objects/BitpandaTransaction.cs
+++ b/src/CryptoTracker/CryptoTracker/Import/Objects/BitpandaTransaction.cs
@@ -13,6 +13,7 @@ namespace CryptoTracker.Import.Objects
 
     public class BitpandaTransaction : ICryptoCsvEntry
     {
+        public int Id { get; set; }
         /// <summary>
         /// Interne TransactionId
         /// </summary>

--- a/src/CryptoTracker/CryptoTracker/Import/Objects/MetamaskTrade.cs
+++ b/src/CryptoTracker/CryptoTracker/Import/Objects/MetamaskTrade.cs
@@ -9,6 +9,7 @@ namespace CryptoTracker.Import.Objects
 
     public class MetamaskTrade : ICryptoCsvEntry
     {
+        public int Id { get; set; }
         [Name("Date(UTC)")]
         public DateTimeOffset Date { get; set; }
 

--- a/src/CryptoTracker/CryptoTracker/Import/Objects/MetamaskTransaction.cs
+++ b/src/CryptoTracker/CryptoTracker/Import/Objects/MetamaskTransaction.cs
@@ -10,6 +10,7 @@ namespace CryptoTracker.Import.Objects
 
     public class MetamaskTransaction : ICryptoCsvEntry
     {
+        public int Id { get; set; }
         /// <summary>
         /// Datum in ISO 8601 und CET
         /// </summary>

--- a/src/CryptoTracker/CryptoTracker/Import/Objects/OkxDeposit.cs
+++ b/src/CryptoTracker/CryptoTracker/Import/Objects/OkxDeposit.cs
@@ -9,6 +9,7 @@ namespace CryptoTracker.Import.Objects
 
     public class OkxDeposit : ICryptoCsvEntry
     {
+        public int Id { get; set; }
         [Name("Date(UTC)")]
         public DateTimeOffset Date { get; set; }
 

--- a/src/CryptoTracker/CryptoTracker/Import/Objects/OkxTrade.cs
+++ b/src/CryptoTracker/CryptoTracker/Import/Objects/OkxTrade.cs
@@ -9,6 +9,7 @@ namespace CryptoTracker.Import.Objects
 
     public class OkxTrade : ICryptoCsvEntry
     {
+        public int Id { get; set; }
         [Name("Date(UTC)")]
         public DateTimeOffset Date { get; set; }
 

--- a/tests/CryptoTracker.Tests/BinanceDepositImporterTests.cs
+++ b/tests/CryptoTracker.Tests/BinanceDepositImporterTests.cs
@@ -1,0 +1,34 @@
+using CryptoTracker.Entities;
+using CryptoTracker.Import;
+using FluentAssertions;
+
+namespace CryptoTracker.Tests;
+
+public class BinanceDepositImporterTests
+{
+    private const string Wallet = "Main";
+
+    [Fact]
+    public async Task Import_ParsesDeposits()
+    {
+        const string csv = "Date(UTC);Coin;Network;Amount;TransactionFee;Address;TXID;Comment\n" +
+            "29.12.2017 21:10;BTC;BTC;0,57127657;0;1BvBMrv6gnwf...;a3f1c7...4d1391;von bitcoin.de\n" +
+            "31.12.2017 13:30;BTC;BTC;0,01907041;0;1BvBMrv6gnwf...;f7d12e...29ea1;von bitcoin.de";
+
+        using var context = TestHelper.CreateContext();
+        var importer = new BinanceDepositImporter(context);
+        await importer.Import(new ImportArgs { Wallet = Wallet }, () => TestHelper.CreateStream(csv));
+
+        context.CryptoTransactions.Should().HaveCount(2);
+        var tx = context.CryptoTransactions.First();
+        tx.Wallet.Should().Be(Wallet);
+        tx.TransactionType.Should().Be(TransactionType.Receive);
+        tx.Symbol.Should().Be("BTC");
+        tx.Quantity.Should().Be(0.57127657m);
+        tx.QuantityAfterFee.Should().Be(0.57127657m);
+        tx.Address.Should().StartWith("1BvBMrv6");
+        ((IFlow)tx).FlowDirection.Should().Be(FlowDirection.Inflow);
+        ((IFlow)tx).FlowAmount.Should().Be(tx.QuantityAfterFee);
+        tx.OppositeTransactionId.Should().BeNull();
+    }
+}

--- a/tests/CryptoTracker.Tests/BinanceTradeImporterTests.cs
+++ b/tests/CryptoTracker.Tests/BinanceTradeImporterTests.cs
@@ -1,0 +1,49 @@
+using CryptoTracker.Entities;
+using CryptoTracker.Import;
+using CryptoTracker.Import.Objects;
+using FluentAssertions;
+
+namespace CryptoTracker.Tests;
+
+public class BinanceTradeImporterTests
+{
+    private const string Wallet = "Main";
+
+    [Fact]
+    public async Task Import_ParsesTradesAndLinksPairs()
+    {
+        const string csv = "Date(UTC),Pair,Side,Price,Executed,Amount,Fee\n" +
+            "2023-11-11 14:02:15,LTCETH,BUY,0.0508376,1.63850661LTC,0.06ETH,0.000LTC\n" +
+            "2024-03-17 18:29:02,LTCUSDT,SELL,70.60922383,0.56LTC,48.216USDT,0.048216USDT\n" +
+            "2018-01-23 20:17:13,ADAETH,BUY,0.00069169,148.0000000000ADA,0.08496976ETH,0.0031142300BNB";
+
+        using var context = TestHelper.CreateContext();
+        var importer = new BinanceTradeImporter(context);
+        await importer.Import(new ImportArgs { Wallet = Wallet }, () => TestHelper.CreateStream(csv));
+
+        context.CryptoTrades.Should().HaveCount(6);
+
+        var firstSell = context.CryptoTrades.First(t => t.TradeType == TradeType.Sell);
+        var firstBuy = context.CryptoTrades.First(t => t.TradeType == TradeType.Buy && t.DateTime == firstSell.DateTime);
+
+        firstSell.Symbol.Should().Be("ETH");
+        firstSell.OpositeSymbol.Should().Be("LTC");
+        firstSell.Wallet.Should().Be(Wallet);
+        firstSell.Price.Should().BeApproximately(1m / 0.0508376m, 0.0000001m);
+        firstSell.Quantity.Should().Be(0.06m);
+        firstSell.QuantityAfterFee.Should().Be(0.06m);
+        ((IFlow)firstSell).FlowDirection.Should().Be(FlowDirection.Outflow);
+        ((IFlow)firstSell).FlowAmount.Should().Be(0.06m);
+
+        firstBuy.Symbol.Should().Be("LTC");
+        firstBuy.OpositeSymbol.Should().Be("ETH");
+        firstBuy.Price.Should().Be(0.0508376m);
+        firstBuy.Quantity.Should().Be(1.63850661m);
+        firstBuy.QuantityAfterFee.Should().Be(1.63850661m);
+        ((IFlow)firstBuy).FlowDirection.Should().Be(FlowDirection.Inflow);
+        ((IFlow)firstBuy).FlowAmount.Should().Be(1.63850661m);
+
+        firstSell.OppositeTradeId.Should().Be(firstBuy.Id);
+        firstBuy.OppositeTradeId.Should().Be(firstSell.Id);
+    }
+}

--- a/tests/CryptoTracker.Tests/BinanceWithdrawalImporterTests.cs
+++ b/tests/CryptoTracker.Tests/BinanceWithdrawalImporterTests.cs
@@ -1,0 +1,32 @@
+using CryptoTracker.Entities;
+using CryptoTracker.Import;
+using FluentAssertions;
+
+namespace CryptoTracker.Tests;
+
+public class BinanceWithdrawalImporterTests
+{
+    private const string Wallet = "Main";
+
+    [Fact]
+    public async Task Import_ParsesWithdrawals()
+    {
+        const string csv = "Date(UTC);Coin;Network;Amount;TransactionFee;Address;TXID;Comment\n" +
+            "02.02.2018 09:14;BTC;BTC;0,050;0,0005;3J98t1WpEZ73...;c47dd1...2ef9;an eigene Wallet";
+
+        using var context = TestHelper.CreateContext();
+        var importer = new BinanceWithdrawalImporter(context);
+        await importer.Import(new ImportArgs { Wallet = Wallet }, () => TestHelper.CreateStream(csv));
+
+        context.CryptoTransactions.Should().HaveCount(1);
+        var tx = context.CryptoTransactions.First();
+        tx.TransactionType.Should().Be(TransactionType.Send);
+        tx.Symbol.Should().Be("BTC");
+        tx.Quantity.Should().Be(0.050m + 0.0005m);
+        tx.Fee.Should().Be(0.0005m);
+        tx.QuantityAfterFee.Should().Be(0.050m);
+        ((IFlow)tx).FlowDirection.Should().Be(FlowDirection.Outflow);
+        ((IFlow)tx).FlowAmount.Should().Be(0.0505m); // outflow uses Quantity
+        tx.OppositeTransactionId.Should().BeNull();
+    }
+}

--- a/tests/CryptoTracker.Tests/BitcoinDeTransactionImporterTests.cs
+++ b/tests/CryptoTracker.Tests/BitcoinDeTransactionImporterTests.cs
@@ -1,0 +1,32 @@
+using CryptoTracker.Entities;
+using CryptoTracker.Import;
+using FluentAssertions;
+
+namespace CryptoTracker.Tests;
+
+public class BitcoinDeTransactionImporterTests
+{
+    private const string Wallet = "Main";
+
+    [Fact]
+    public async Task Import_ParsesTradesAndTransactions()
+    {
+        const string csv = "Datum;Typ;Währung;Referenz;Adresse;Kurs;\"Einheit (Kurs)\";\"Crypto vor Gebühr\";\"Menge vor Gebühr\";\"Einheit (Menge vor Gebühr)\";\"Crypto nach Bitcoin.de-Gebühr\";\"Menge nach Bitcoin.de-Gebühr\";\"Einheit (Menge nach Bitcoin.de-Gebühr)\";\"Zu- / Abgang\";Kontostand;Kommentar\n" +
+            "2013-04-17 15:35:15;Kauf;BTC;QW3A9T;;61.00;BTC / EUR;1.00000000;61.00;EUR;0.99000000;60.69;EUR;0.99000000;0.99000000;\n";
+
+        using var context = TestHelper.CreateContext();
+        var importer = new BitcoinDeTransactionImporter(context);
+        await importer.Import(new ImportArgs { Wallet = Wallet }, () => TestHelper.CreateStream(csv));
+
+        context.CryptoTrades.Should().HaveCount(2);
+        var sell = context.CryptoTrades.First(t => t.TradeType == TradeType.Sell);
+        var buy = context.CryptoTrades.First(t => t.TradeType == TradeType.Buy);
+        sell.Symbol.Should().Be("EUR");
+        sell.OpositeSymbol.Should().Be("BTC");
+        sell.Price.Should().BeApproximately(61m, 0.00001m);
+        buy.Symbol.Should().Be("BTC");
+        buy.Quantity.Should().Be(1.00000000m);
+        sell.OppositeTradeId.Should().Be(buy.Id);
+        buy.OppositeTradeId.Should().Be(sell.Id);
+    }
+}

--- a/tests/CryptoTracker.Tests/BitpandaTransactionImporterTests.cs
+++ b/tests/CryptoTracker.Tests/BitpandaTransactionImporterTests.cs
@@ -1,0 +1,31 @@
+using CryptoTracker.Entities;
+using CryptoTracker.Import;
+using FluentAssertions;
+
+namespace CryptoTracker.Tests;
+
+public class BitpandaTransactionImporterTests
+{
+    private const string Wallet = "Main";
+
+    [Fact]
+    public async Task Import_ParsesBuySellAndLinksTrades()
+    {
+        const string csv = "Transaction ID,Date,Buy/Sell,Asset,Fiat Amount,Fiat Currency,Crypto Amount,Crypto Currency,Fee,Fee asset,Spread,Spread Currency,Tax Fiat,Address,Comment\n" +
+            "c1d2f3e4-...,2022-01-03T12:56:40+01:00,Buy,ADA,100,EUR,300,ADA,1,ADA,0,EUR,0,,bitpanda.com";
+
+        using var context = TestHelper.CreateContext();
+        var importer = new BitpandaTransactionImporter(context);
+        await importer.Import(new ImportArgs { Wallet = Wallet }, () => TestHelper.CreateStream(csv));
+
+        context.CryptoTrades.Should().HaveCount(2);
+        var sell = context.CryptoTrades.First(t => t.TradeType == TradeType.Sell);
+        var buy = context.CryptoTrades.First(t => t.TradeType == TradeType.Buy);
+        sell.Symbol.Should().Be("EUR");
+        sell.OpositeSymbol.Should().Be("ADA");
+        buy.Symbol.Should().Be("ADA");
+        buy.Quantity.Should().Be(300m);
+        sell.OppositeTradeId.Should().Be(buy.Id);
+        buy.OppositeTradeId.Should().Be(sell.Id);
+    }
+}

--- a/tests/CryptoTracker.Tests/CryptoTracker.Tests.csproj
+++ b/tests/CryptoTracker.Tests/CryptoTracker.Tests.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="FluentAssertions" Version="6.12.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../src/CryptoTracker/CryptoTracker/CryptoTracker.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/CryptoTracker.Tests/MetamaskTradeImporterTests.cs
+++ b/tests/CryptoTracker.Tests/MetamaskTradeImporterTests.cs
@@ -1,0 +1,29 @@
+using CryptoTracker.Entities;
+using CryptoTracker.Import;
+using FluentAssertions;
+
+namespace CryptoTracker.Tests;
+
+public class MetamaskTradeImporterTests
+{
+    private const string Wallet = "Main";
+
+    [Fact]
+    public async Task Import_ParsesTrades()
+    {
+        const string csv = "Date(UTC);Pair;Side;Price;Executed;Amount;Fee;Tradingplatform\n" +
+            "02.07.2021;BabyDo-ETH;BUY;1,0142E-12 ETH;1,8E+11 BabyDo;0,17 ETH;2E+10 BabyDo;pancakeswap.finance";
+
+        using var context = TestHelper.CreateContext();
+        var importer = new MetamaskTradeImporter(context);
+        await importer.Import(new ImportArgs { Wallet = Wallet }, () => TestHelper.CreateStream(csv));
+
+        context.CryptoTrades.Should().HaveCount(2);
+        var sell = context.CryptoTrades.First(t => t.TradeType == TradeType.Sell);
+        var buy = context.CryptoTrades.First(t => t.TradeType == TradeType.Buy);
+        sell.Symbol.Should().Be("BabyDo");
+        buy.Symbol.Should().Be("ETH");
+        sell.OppositeTradeId.Should().Be(buy.Id);
+        buy.OppositeTradeId.Should().Be(sell.Id);
+    }
+}

--- a/tests/CryptoTracker.Tests/MetamaskTransactionImporterTests.cs
+++ b/tests/CryptoTracker.Tests/MetamaskTransactionImporterTests.cs
@@ -1,0 +1,31 @@
+using CryptoTracker.Entities;
+using CryptoTracker.Import;
+using FluentAssertions;
+
+namespace CryptoTracker.Tests;
+
+public class MetamaskTransactionImporterTests
+{
+    private const string Wallet = "Main";
+
+    [Fact]
+    public async Task Import_ParsesTransactions()
+    {
+        const string csv = "Datum;Typ;Coin;Network;Amount;TransactionFee;Kommentar\n" +
+            "01.10.2021 12:24;Eingang;ETH;BSC;0,179936;0,000064;von binance.com";
+
+        using var context = TestHelper.CreateContext();
+        var importer = new MetamaskTransactionImporter(context);
+        await importer.Import(new ImportArgs { Wallet = Wallet }, () => TestHelper.CreateStream(csv));
+
+        context.CryptoTransactions.Should().HaveCount(1);
+        var tx = context.CryptoTransactions.First();
+        tx.TransactionType.Should().Be(TransactionType.Receive);
+        tx.Symbol.Should().Be("ETH");
+        tx.Quantity.Should().Be(0.179936m);
+        tx.Fee.Should().Be(0.000064m);
+        tx.QuantityAfterFee.Should().Be(0.179872m);
+        ((IFlow)tx).FlowDirection.Should().Be(FlowDirection.Inflow);
+        ((IFlow)tx).FlowAmount.Should().Be(tx.QuantityAfterFee);
+    }
+}

--- a/tests/CryptoTracker.Tests/OkxDepositImporterTests.cs
+++ b/tests/CryptoTracker.Tests/OkxDepositImporterTests.cs
@@ -1,0 +1,29 @@
+using CryptoTracker.Entities;
+using CryptoTracker.Import;
+using FluentAssertions;
+
+namespace CryptoTracker.Tests;
+
+public class OkxDepositImporterTests
+{
+    private const string Wallet = "Main";
+
+    [Fact]
+    public async Task Import_ParsesDeposits()
+    {
+        const string csv = "Date(UTC);Coin;Network;Amount;Address;Kommentar\n" +
+            "23.01.2018 20:25;ETH;ETH;0,400000;0x55a7e...c393;von bitcoin.de";
+
+        using var context = TestHelper.CreateContext();
+        var importer = new OkxDepositImporter(context);
+        await importer.Import(new ImportArgs { Wallet = Wallet }, () => TestHelper.CreateStream(csv));
+
+        context.CryptoTransactions.Should().HaveCount(1);
+        var tx = context.CryptoTransactions.First();
+        tx.TransactionType.Should().Be(TransactionType.Receive);
+        tx.Symbol.Should().Be("ETH");
+        tx.Quantity.Should().Be(0.400000m);
+        tx.Network.Should().Be("ETH");
+        ((IFlow)tx).FlowDirection.Should().Be(FlowDirection.Inflow);
+    }
+}

--- a/tests/CryptoTracker.Tests/OkxTradeImporterTests.cs
+++ b/tests/CryptoTracker.Tests/OkxTradeImporterTests.cs
@@ -1,0 +1,35 @@
+using CryptoTracker.Entities;
+using CryptoTracker.Import;
+using FluentAssertions;
+
+namespace CryptoTracker.Tests;
+
+public class OkxTradeImporterTests
+{
+    private const string Wallet = "Main";
+
+    [Fact]
+    public async Task Import_ParsesTrades()
+    {
+        const string csv = "Date(UTC);Pair;Side;Price;Executed;Amount\n" +
+            "2018-01-23 20:17:13;IOTAUSDT;BUY;2,37;1000,0;2370,00USDT";
+
+        using var context = TestHelper.CreateContext();
+        var importer = new OkxTradeImporter(context);
+        await importer.Import(new ImportArgs { Wallet = Wallet }, () => TestHelper.CreateStream(csv));
+
+        context.CryptoTrades.Should().HaveCount(2);
+        var sell = context.CryptoTrades.First(t => t.TradeType == TradeType.Sell);
+        var buy = context.CryptoTrades.First(t => t.TradeType == TradeType.Buy);
+
+        sell.Symbol.Should().Be("IOTA");
+        sell.OpositeSymbol.Should().Be("USDT");
+        sell.Quantity.Should().Be(1000m);
+        sell.Price.Should().BeApproximately(2.37m, 0.00001m);
+        buy.Symbol.Should().Be("USDT");
+        buy.Quantity.Should().Be(2370m);
+        buy.Price.Should().BeApproximately(1m / sell.Price, 0.00001m);
+        sell.OppositeTradeId.Should().Be(buy.Id);
+        buy.OppositeTradeId.Should().Be(sell.Id);
+    }
+}

--- a/tests/CryptoTracker.Tests/TestHelper.cs
+++ b/tests/CryptoTracker.Tests/TestHelper.cs
@@ -1,0 +1,19 @@
+using CryptoTracker;
+using Microsoft.EntityFrameworkCore;
+using System.Text;
+
+namespace CryptoTracker.Tests;
+
+public static class TestHelper
+{
+    public static CryptoTrackerDbContext CreateContext()
+    {
+        var options = new DbContextOptionsBuilder<CryptoTrackerDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        return new CryptoTrackerDbContext(options);
+    }
+
+    public static Stream CreateStream(string data)
+        => new MemoryStream(Encoding.UTF8.GetBytes(data));
+}


### PR DESCRIPTION
## Summary
- add xUnit test project with FluentAssertions
- implement importer tests for Binance, Bitpanda, Bitcoin.de, Okx and Metamask
- extend solution with new test project

## Testing
- `dotnet test CryptoTracker.sln` *(fails: Restore failed with 1 error)*