### PR TITLE
Fix build warnings and errors

### DIFF
--- a/src/CryptoTracker/CryptoTracker/Entities/CryptoTrade.cs
+++ b/src/CryptoTracker/CryptoTracker/Entities/CryptoTrade.cs
@@ -11,18 +11,18 @@ public enum TradeType
 public class CryptoTrade : IFlow
 {
     public int Id { get; set; }
-    public string Wallet { get; set; }
+    public string Wallet { get; set; } = string.Empty;
     public DateTime DateTime { get; set; }
 
     /// <summary>
     /// Welcher Coin wurde gekauft/verkauft
     /// </summary>
-    public string Symbol { get; set; }
+    public string Symbol { get; set; } = string.Empty;
 
     /// <summary>
     /// Mit welchen Coin wurde bezahlt / Betrag erhalten.
     /// </summary>
-    public string OpositeSymbol { get; set; }
+    public string OpositeSymbol { get; set; } = string.Empty;
 
     public TradeType TradeType { get; set; }
 
@@ -42,7 +42,7 @@ public class CryptoTrade : IFlow
     /// </summary>
     public decimal Fee { get; set; }
     public decimal ForeignFee {  get; set; }
-    public string ForeignFeeSymbol {  get; set; }
+    public string ForeignFeeSymbol {  get; set; } = string.Empty;
 
     /// <summary>
     /// Externe Referenz - z.B. TransactionId bei Kauf Fiat->Crypto

--- a/src/CryptoTracker/CryptoTracker/Entities/CryptoTransaction.cs
+++ b/src/CryptoTracker/CryptoTracker/Entities/CryptoTransaction.cs
@@ -15,10 +15,10 @@ public class CryptoTransaction : IFlow
     /// <summary>
     /// Wenn TransactionType: Receive => Zielwallet / bei Send => Quellwallet
     /// </summary>
-    public string Wallet { get; set; }
+    public string Wallet { get; set; } = string.Empty;
     public DateTime DateTime { get; set; }
     public TransactionType TransactionType { get; set; }
-    public string Symbol { get; set; }
+    public string Symbol { get; set; } = string.Empty;
     /// <summary>
     /// Anzahl vor Gebührabzug
     /// </summary>

--- a/src/CryptoTracker/CryptoTracker/Import/BitpandaTransactionImporter.cs
+++ b/src/CryptoTracker/CryptoTracker/Import/BitpandaTransactionImporter.cs
@@ -26,7 +26,7 @@ namespace CryptoTracker.Import
 
         private class BitpandaDecimalConverter : DecimalConverter
         {
-            public override object ConvertFromString(string text, IReaderRow row, MemberMapData memberMapData)
+            public override object? ConvertFromString(string? text, IReaderRow row, MemberMapData memberMapData)
             {
                 if (text == "-")
                     text = "";
@@ -40,7 +40,7 @@ namespace CryptoTracker.Import
 
         private class BitpandaIntConverter : Int32Converter
         {
-            public override object ConvertFromString(string text, IReaderRow row, MemberMapData memberMapData)
+            public override object? ConvertFromString(string? text, IReaderRow row, MemberMapData memberMapData)
             {
                 if (text == "-")
                     text = "";

--- a/src/CryptoTracker/CryptoTracker/Import/ImportArgs.cs
+++ b/src/CryptoTracker/CryptoTracker/Import/ImportArgs.cs
@@ -2,6 +2,6 @@
 {
     public class ImportArgs
     {
-        public string Wallet { get; set; }
+        public string Wallet { get; set; } = string.Empty;
     }
 }

--- a/src/CryptoTracker/CryptoTracker/Import/Objects/BinanceDeposit.cs
+++ b/src/CryptoTracker/CryptoTracker/Import/Objects/BinanceDeposit.cs
@@ -9,13 +9,14 @@ namespace CryptoTracker.Import.Objects
     
     public class BinanceDeposit : ICryptoCsvEntry
     {
+        [Ignore]
         public int Id { get; set; }
         [Name("Date(UTC)")]
         public DateTimeOffset Date { get; set; }
 
-        public string Coin {  get; set; }
+        public string Coin {  get; set; } = string.Empty;
 
-        public string Network { get; set; }
+        public string Network { get; set; } = string.Empty;
 
         /// <summary>
         /// Preis der erhalten wurden (Entspricht Preis nach Fee Abzug?)
@@ -30,13 +31,13 @@ namespace CryptoTracker.Import.Objects
         /// <summary>
         /// Zieladresse
         /// </summary>
-        public string Address {  get; set; }
+        public string Address {  get; set; } = string.Empty;
 
         /// <summary>
         /// Binance TransactionId
         /// </summary>
-        public string TXID { get; set; }
+        public string TXID { get; set; } = string.Empty;
 
-        public string Comment {  get; set; }
+        public string Comment {  get; set; } = string.Empty;
     }
 }

--- a/src/CryptoTracker/CryptoTracker/Import/Objects/BinanceTrade.cs
+++ b/src/CryptoTracker/CryptoTracker/Import/Objects/BinanceTrade.cs
@@ -9,6 +9,7 @@ namespace CryptoTracker.Import.Objects
 
     public class BinanceTrade : ICryptoCsvEntry
     {
+        [Ignore]
         public int Id { get; set; }
         [Name("Date(UTC)")]
         public DateTimeOffset Date { get; set; }
@@ -16,12 +17,12 @@ namespace CryptoTracker.Import.Objects
         /// <summary>
         /// "{PrimarySymbol}{SecondardSymbol}" z.B. "ETHUSDT"
         /// </summary>
-        public string Pair {  get; set; }
+        public string Pair {  get; set; } = string.Empty;
 
         /// <summary>
         /// SELL or BUY
         /// </summary>
-        public string Side { get; set; }
+        public string Side { get; set; } = string.Empty;
 
         /// <summary>
         /// Preis ausgehend von PrimarySymbol (1 {PrimarySymbol} kostet x {SecondardSymbol})
@@ -32,20 +33,20 @@ namespace CryptoTracker.Import.Objects
         /// Anzahl an {PrimarySymbol} die gekauft/verkauft wurden.
         /// Nach der Zahl steht das Währungssymbol. z.B. "0.1374ETH"
         /// </summary>
-        public string Executed { get; set; }
+        public string Executed { get; set; } = string.Empty;
 
         /// <summary>
         /// Anzahl an Coins in {SecondardSymbol} die im Gegenzug bezahlt bzw. erhalten wurden.
         /// Entspricht Wert vor Fee-Abzug.
         /// Nach der Zahl steht das Währungssymbol. z.B. "320.02521USDT"
         /// </summary>
-        public string Amount { get; set; }
+        public string Amount { get; set; } = string.Empty;
 
         /// <summary>
         /// Anzahl von {SecondardSymbol} oder alternativ Währung, die beim Trade angefallen sind.
         /// 
         /// Nach der Zahl steht das Währungssymbol. z.B. "0.32002521USDT" oder "0.0079859100BNB"
         /// </summary>
-        public string Fee { get; set; }
+        public string Fee { get; set; } = string.Empty;
     }
 }

--- a/src/CryptoTracker/CryptoTracker/Import/Objects/BinanceWithdrawal.cs
+++ b/src/CryptoTracker/CryptoTracker/Import/Objects/BinanceWithdrawal.cs
@@ -9,13 +9,14 @@ namespace CryptoTracker.Import.Objects
 
     public class BinanceWithdrawal : ICryptoCsvEntry
     {
+        [Ignore]
         public int Id { get; set; }
         [Name("Date(UTC)")]
         public DateTimeOffset Date { get; set; }
 
-        public string Coin {  get; set; }
+        public string Coin {  get; set; } = string.Empty;
 
-        public string Network { get; set; }
+        public string Network { get; set; } = string.Empty;
 
         /// <summary>
         /// Preis die ausbezahlt wurden. Entspricht Preis nach Fee Abzug.
@@ -30,13 +31,13 @@ namespace CryptoTracker.Import.Objects
         /// <summary>
         /// Zieladresse
         /// </summary>
-        public string Address {  get; set; }
+        public string Address {  get; set; } = string.Empty;
 
         /// <summary>
         /// Binance TransactionId
         /// </summary>
-        public string TXID { get; set; }
+        public string TXID { get; set; } = string.Empty;
 
-        public string Comment {  get; set; }
+        public string Comment {  get; set; } = string.Empty;
     }
 }

--- a/src/CryptoTracker/CryptoTracker/Import/Objects/BitcoinDeTransaction.cs
+++ b/src/CryptoTracker/CryptoTracker/Import/Objects/BitcoinDeTransaction.cs
@@ -11,29 +11,30 @@ namespace CryptoTracker.Import.Objects
 
     public class BitcoinDeTransaction : ICryptoCsvEntry
     {
+        [Ignore]
         public int Id { get; set; }
         public DateTime Datum { get; set; }
 
         /// <summary>
         /// Kauf, Verkauf, Auszahlung, Einzahlung, Netzwerk-Gebühr, Partnerprogramm, Korrekturposition, Registrierung, Initialisierung
         /// </summary>
-        public string Typ {  get; set; }
+        public string Typ {  get; set; } = string.Empty;
 
         /// <summary>
         /// Symbol der Cryptowährung
         /// </summary>
         [Name("Währung")]
-        public string Waehrung { get; set; }
+        public string Waehrung { get; set; } = string.Empty;
 
         /// <summary>
         /// z.B. Transaction Hash bei Ein- oder Auszahlung oder Bitcoin.de TransactionId bei Kauf/Verkauf
         /// </summary>
-        public string Referenz { get; set; }
+        public string Referenz { get; set; } = string.Empty;
 
         /// <summary>
         /// Ziel- oder Quelladdresse bei einer Crypto Transaktion
         /// </summary>
-        public string Adresse { get; set; }
+        public string Adresse { get; set; } = string.Empty;
 
         /// <summary>
         /// Kurs in EUR (z.B. 61 EUR pro BTC)
@@ -44,7 +45,7 @@ namespace CryptoTracker.Import.Objects
         /// z.B. BTC / EUR
         /// </summary>
         [Name("Einheit (Kurs)")]
-        public string EinheitKurs { get; set; }
+        public string EinheitKurs { get; set; } = string.Empty;
 
         /// <summary>
         /// z.B. Anzahl an BTC/ETH vor Gebührenabzug. z.B. 1.000
@@ -62,7 +63,7 @@ namespace CryptoTracker.Import.Objects
         /// z.B. EUR
         /// </summary>
         [Name("Einheit (Menge vor Gebühr)")]
-        public string EinheitMengeVorGebuehr { get; set; }
+        public string EinheitMengeVorGebuehr { get; set; } = string.Empty;
 
         /// <summary>
         /// z.B. Anzahl an BTC/ETH nach Gebührenabzug. z.B. 1.000
@@ -80,7 +81,7 @@ namespace CryptoTracker.Import.Objects
         /// z.B. EUR
         /// </summary>
         [Name("Einheit (Menge nach Bitcoin.de-Gebühr)")]
-        public string EinheitMengeNachGebuehr { get; set; }
+        public string EinheitMengeNachGebuehr { get; set; } = string.Empty;
 
         /// <summary>
         /// Menge, die vom Konto zu- oder abgebucht wurden.
@@ -93,6 +94,6 @@ namespace CryptoTracker.Import.Objects
         /// </summary>
         public decimal Kontostand {  get; set; }
 
-        public string Kommentar { get; set; }
+        public string Kommentar { get; set; } = string.Empty;
     }
 }

--- a/src/CryptoTracker/CryptoTracker/Import/Objects/BitpandaTransaction.cs
+++ b/src/CryptoTracker/CryptoTracker/Import/Objects/BitpandaTransaction.cs
@@ -12,12 +12,13 @@ namespace CryptoTracker.Import.Objects
 
     public class BitpandaTransaction : ICryptoCsvEntry
     {
+        [Ignore]
         public int Id { get; set; }
         /// <summary>
         /// Interne TransactionId
         /// </summary>
         [Name("Transaction ID")]
-        public string TransactionId { get; set; }
+        public string TransactionId { get; set; } = string.Empty;
 
         /// <summary>
         /// Datum in ISO 8601 und CET
@@ -28,13 +29,13 @@ namespace CryptoTracker.Import.Objects
         /// deposit, withdrawal, buy, sell
         /// </summary>
         [Name("Transaction Type")]
-        public string TransactionType {  get; set; }
+        public string TransactionType {  get; set; } = string.Empty;
 
         /// <summary>
         /// incoming, outgoing
         /// </summary>
         [Name("In/Out")]
-        public string InOut { get; set; }
+        public string InOut { get; set; } = string.Empty;
 
         /// <summary>
         /// Betrag in Fiat für Kauf oder Verkauf aber auch den aktuellen Wert bei Crypto Aus-/Einzahlung.
@@ -45,7 +46,7 @@ namespace CryptoTracker.Import.Objects
         /// <summary>
         /// Symbol der Fiat Währung
         /// </summary>
-        public string Fiat { get; set; }
+        public string Fiat { get; set; } = string.Empty;
 
         /// <summary>
         /// Menge an Cryptos vor Gebührenabzug bei Transaktion
@@ -56,7 +57,7 @@ namespace CryptoTracker.Import.Objects
         /// <summary>
         /// Symbol der Asset Währung
         /// </summary>
-        public string Asset { get; set; }
+        public string Asset { get; set; } = string.Empty;
 
         /// <summary>
         /// Aktuelle Preis der Cryptowährung in der {AssetMarketPriceCurrency} Währung (in der Regel Fiat Währung).
@@ -65,13 +66,13 @@ namespace CryptoTracker.Import.Objects
         public decimal? AssetMarketPrice { get; set; }
 
         [Name("Asset market price currency")]
-        public string AssetMarketPriceCurrency { get; set; }
+        public string AssetMarketPriceCurrency { get; set; } = string.Empty;
 
         /// <summary>
         /// Asset Class z.B. Cryptocurrency
         /// </summary>
         [Name("Asset class")]
-        public string AssetClass { get; set; }
+        public string AssetClass { get; set; } = string.Empty;
 
         [Name("Product ID")]
         public int? ProductID { get; set; }
@@ -95,8 +96,8 @@ namespace CryptoTracker.Import.Objects
         /// <summary>
         /// Ziel- oder Quell-Hash Addresse bei einer Cryptotransaktion
         /// </summary>
-        public string Address { get; set; }
+        public string Address { get; set; } = string.Empty;
 
-        public string Comment { get; set; }
+        public string Comment { get; set; } = string.Empty;
     }
 }

--- a/src/CryptoTracker/CryptoTracker/Import/Objects/MetamaskTrade.cs
+++ b/src/CryptoTracker/CryptoTracker/Import/Objects/MetamaskTrade.cs
@@ -9,6 +9,7 @@ namespace CryptoTracker.Import.Objects
 
     public class MetamaskTrade : ICryptoCsvEntry
     {
+        [Ignore]
         public int Id { get; set; }
         [Name("Date(UTC)")]
         public DateTimeOffset Date { get; set; }
@@ -16,38 +17,38 @@ namespace CryptoTracker.Import.Objects
         /// <summary>
         /// "{PrimarySymbol}{SecondardSymbol}" z.B. "ETHUSDT"
         /// </summary>
-        public string Pair {  get; set; }
+        public string Pair {  get; set; } = string.Empty;
 
         /// <summary>
         /// SELL or BUY
         /// </summary>
-        public string Side { get; set; }
+        public string Side { get; set; } = string.Empty;
 
         /// <summary>
         /// Preis ausgehend von PrimarySymbol (1 {PrimarySymbol} kostet x {SecondardSymbol})
         /// </summary>
-        public string Price {  get; set; }
+        public string Price {  get; set; } = string.Empty;
 
         /// <summary>
         /// Anzahl an {PrimarySymbol} die gekauft/verkauft wurden.
         /// Nach der Zahl steht das Währungssymbol. z.B. "0.1374ETH"
         /// </summary>
-        public string Executed { get; set; }
+        public string Executed { get; set; } = string.Empty;
 
         /// <summary>
         /// Anzahl an Coins in {SecondardSymbol} die im Gegenzug bezahlt bzw. erhalten wurden.
         /// Entspricht Wert vor Fee-Abzug.
         /// Nach der Zahl steht das Währungssymbol. z.B. "320.02521USDT"
         /// </summary>
-        public string Amount { get; set; }
+        public string Amount { get; set; } = string.Empty;
 
         /// <summary>
         /// Anzahl von {SecondardSymbol} oder alternativ Währung, die beim Trade angefallen sind.
         /// 
         /// Nach der Zahl steht das Währungssymbol. z.B. "0.32002521USDT" oder "0.0079859100BNB"
         /// </summary>
-        public string Fee { get; set; }
+        public string Fee { get; set; } = string.Empty;
 
-        public string Tradingplatform { get; set; }
+        public string Tradingplatform { get; set; } = string.Empty;
     }
 }

--- a/src/CryptoTracker/CryptoTracker/Import/Objects/MetamaskTransaction.cs
+++ b/src/CryptoTracker/CryptoTracker/Import/Objects/MetamaskTransaction.cs
@@ -9,6 +9,7 @@ namespace CryptoTracker.Import.Objects
 
     public class MetamaskTransaction : ICryptoCsvEntry
     {
+        [Ignore]
         public int Id { get; set; }
         /// <summary>
         /// Datum in ISO 8601 und CET
@@ -18,17 +19,17 @@ namespace CryptoTracker.Import.Objects
         /// <summary>
         /// Eingang, Ausgang
         /// </summary>
-        public string Typ { get; set; }
+        public string Typ { get; set; } = string.Empty;
 
         /// <summary>
         /// Symbol der Cryptowährung
         /// </summary>
-        public string Coin { get; set; }
+        public string Coin { get; set; } = string.Empty;
 
         /// <summary>
         /// Netzwerk über das die Coins übertragen wurden
         /// </summary>
-        public string Network { get; set; }
+        public string Network { get; set; } = string.Empty;
 
         /// <summary>
         /// Anzahl der Coins vor Gebührenabzug
@@ -40,6 +41,6 @@ namespace CryptoTracker.Import.Objects
         /// </summary>
         public decimal TransactionFee { get; set; }
 
-        public string Kommentar { get; set; }
+        public string Kommentar { get; set; } = string.Empty;
     }
 }

--- a/src/CryptoTracker/CryptoTracker/Import/Objects/OkxDeposit.cs
+++ b/src/CryptoTracker/CryptoTracker/Import/Objects/OkxDeposit.cs
@@ -9,13 +9,14 @@ namespace CryptoTracker.Import.Objects
 
     public class OkxDeposit : ICryptoCsvEntry
     {
+        [Ignore]
         public int Id { get; set; }
         [Name("Date(UTC)")]
         public DateTimeOffset Date { get; set; }
 
-        public string Coin {  get; set; }
+        public string Coin {  get; set; } = string.Empty;
 
-        public string Network { get; set; }
+        public string Network { get; set; } = string.Empty;
 
         /// <summary>
         /// Preis die ausbezahlt wurden. Entspricht Preis nach Fee Abzug.
@@ -25,8 +26,9 @@ namespace CryptoTracker.Import.Objects
         /// <summary>
         /// Zieladresse
         /// </summary>
-        public string Address {  get; set; }
+        public string Address {  get; set; } = string.Empty;
 
-        public string Kommentar {  get; set; }
+        [Name("Comment")]
+        public string Kommentar {  get; set; } = string.Empty;
     }
 }

--- a/src/CryptoTracker/CryptoTracker/Import/Objects/OkxTrade.cs
+++ b/src/CryptoTracker/CryptoTracker/Import/Objects/OkxTrade.cs
@@ -9,6 +9,7 @@ namespace CryptoTracker.Import.Objects
 
     public class OkxTrade : ICryptoCsvEntry
     {
+        [Ignore]
         public int Id { get; set; }
         [Name("Date(UTC)")]
         public DateTimeOffset Date { get; set; }
@@ -16,18 +17,18 @@ namespace CryptoTracker.Import.Objects
         /// <summary>
         /// "{PrimarySymbol}{SecondardSymbol}" z.B. "ETHUSDT"
         /// </summary>
-        public string Pair {  get; set; }
+        public string Pair {  get; set; } = string.Empty;
 
         /// <summary>
         /// SELL or BUY
         /// </summary>
-        public string Side { get; set; }
+        public string Side { get; set; } = string.Empty;
 
         /// <summary>
         /// Preis ausgehend von PrimarySymbol (1 {PrimarySymbol} kostet x {SecondardSymbol})
         /// Nach der Zahl steht das Währungssymbol. z.B. "0.1374ETH"
         /// </summary>
-        public string Price {  get; set; }
+        public string Price {  get; set; } = string.Empty;
 
         /// <summary>
         /// Anzahl an {PrimarySymbol} die gekauft/verkauft wurden.

--- a/src/CryptoTracker/CryptoTracker/Import/UtcDateTimeConverter.cs
+++ b/src/CryptoTracker/CryptoTracker/Import/UtcDateTimeConverter.cs
@@ -6,9 +6,9 @@ namespace CryptoTracker.Import
 {
     public class UtcDateTimeConverter : DateTimeConverter
     {
-        public override object ConvertFromString(string text, IReaderRow row, MemberMapData memberMapData)
+        public override object? ConvertFromString(string? text, IReaderRow row, MemberMapData memberMapData)
         {
-            if (DateTime.TryParse(text, out DateTime parsedDateTime))
+            if (text != null && DateTime.TryParse(text, out DateTime parsedDateTime))
             {
                 return new DateTimeOffset(DateTime.SpecifyKind(parsedDateTime, DateTimeKind.Utc));
             }

--- a/src/CryptoTracker/CryptoTracker/Services/FinanceValueProvider.cs
+++ b/src/CryptoTracker/CryptoTracker/Services/FinanceValueProvider.cs
@@ -18,9 +18,9 @@ public class FinanceValueProvider : IFinanceValueProvider
         try
         {
             Quote quote = await _financeService.GetQuoteAsync($"{symbol}-EUR");
-            return quote.RegularMarketPrice;
+            return Convert.ToDecimal(quote.RegularMarketPrice ?? 0d);
         }
-        catch (FinanceException)
+        catch (FinanceNetException)
         {
             return 0m;
         }

--- a/src/CryptoTracker/CryptoTracker/Startup.cs
+++ b/src/CryptoTracker/CryptoTracker/Startup.cs
@@ -4,6 +4,7 @@ using CryptoTracker.Client.Pages;
 using Microsoft.AspNetCore.Components;
 using CryptoTracker.Services;
 using Finance.Net;
+using Finance.Net.Extensions;
 
 namespace CryptoTracker
 {
@@ -32,7 +33,7 @@ namespace CryptoTracker
                 .AddInteractiveServerComponents()
                 .AddInteractiveWebAssemblyComponents();
 
-            services.AddFinanceNetServiceProvider(new FinanceNetConfiguration()
+            services.AddFinanceNet(new FinanceNetConfiguration()
             {
                 HttpRetryCount = 3
             });


### PR DESCRIPTION
## Summary
- adjust nullable handling and convert double to decimal in `FinanceValueProvider`
- use correct Finance.Net service extension
- update CSV converters for nullable strings
- initialize non-nullable properties in entity and object classes
- mark CSV ID columns as ignored and map headers

## Testing
- `dotnet test` *(fails: CsvHelper header validation exceptions)*