### PR TITLE
Add devcontainer for GitHub Codespaces

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,12 @@
+{
+    "name": "CryptoTracker",
+    "image": "mcr.microsoft.com/devcontainers/dotnet:0-9.0",
+    "customizations": {
+        "vscode": {
+            "settings": {
+                "terminal.integrated.shell.linux": "/bin/bash"
+            }
+        }
+    },
+    "postCreateCommand": "dotnet restore"
+}


### PR DESCRIPTION
## Summary
- add a `.devcontainer` folder with `devcontainer.json`
- use the .NET 9 devcontainer image
- run `dotnet restore` after creating the container

## Testing
- `dotnet test` *(fails: CsvHelper.HeaderValidationException and other test failures)*