### PR TITLE
Auto-fill wallet name from file selector

### DIFF
--- a/src/CryptoTracker/CryptoTracker.Client/Pages/ImportPages/ImportPageBase.razor
+++ b/src/CryptoTracker/CryptoTracker.Client/Pages/ImportPages/ImportPageBase.razor
@@ -67,6 +67,17 @@ else if (Entries.Count > 0)
     private Task HandleFileSelected(InputFileChangeEventArgs e)
     {
         SelectedFile = e.File;
+
+        int indexOfHashtag = e.File.Name.IndexOf('#');
+        if (indexOfHashtag >= 0)
+        {
+            int indexOfLastDot = e.File.Name.LastIndexOf('.');
+            if (indexOfLastDot > indexOfHashtag)
+            {
+                WalletName = e.File.Name.Substring(indexOfHashtag + 1, indexOfLastDot - indexOfHashtag - 1);
+            }
+        }
+
         return Task.CompletedTask;
     }
 


### PR DESCRIPTION
## Summary
- parse the selected file name to automatically populate the wallet name

## Testing
- `dotnet build`
- `dotnet test --no-build` *(fails: CsvHelper.HeaderValidationException, etc.)*