### PR TITLE
Add CryptoTracker logo to header

### DIFF
--- a/src/CryptoTracker/CryptoTracker/Components/Layout/MainLayout.razor
+++ b/src/CryptoTracker/CryptoTracker/Components/Layout/MainLayout.razor
@@ -7,6 +7,7 @@
 
     <main>
         <div class="top-row px-4">
+            <h1 class="logo">CryptoTracker</h1>
             <a href="https://learn.microsoft.com/aspnet/core/" target="_blank">About</a>
         </div>
 

--- a/src/CryptoTracker/CryptoTracker/Components/Layout/MainLayout.razor.css
+++ b/src/CryptoTracker/CryptoTracker/Components/Layout/MainLayout.razor.css
@@ -22,6 +22,13 @@ main {
     align-items: center;
 }
 
+.logo {
+    font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+    font-size: 2rem;
+    font-weight: bold;
+    margin-right: auto;
+}
+
     .top-row ::deep a, .top-row ::deep .btn-link {
         white-space: nowrap;
         margin-left: 1.5rem;


### PR DESCRIPTION
## Summary
- add a large CryptoTracker heading to MainLayout
- style logo in layout CSS

## Testing
- `dotnet test --verbosity normal` *(fails: 7 failed, 2 passed)*