### PR TITLE
Restrict web app auth to current tenant

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -41,6 +41,7 @@ module appService 'appservice/appservice.bicep' = {
     appServicePlanId: appServicePlan.id
     applicationInsightsName: applicationInsights.outputs.name
     azureDbConnectionString: azureDbConnectionString
+    tenantId: tenant().tenantId
   }
 }
 


### PR DESCRIPTION
## Summary
- restrict App Service authentication to only allow current tenant's users
- pass tenant id to appservice module

## Testing
- `dotnet test tests/CryptoTracker.Tests/CryptoTracker.Tests.csproj` *(fails: Sequence contains no elements)*