### PR TITLE
Fix Bitpanda timestamp and Bitcoin.de importer

### DIFF
--- a/src/CryptoTracker/CryptoTracker/Import/BitcoinDeTransactionImporter.cs
+++ b/src/CryptoTracker/CryptoTracker/Import/BitcoinDeTransactionImporter.cs
@@ -15,7 +15,9 @@ namespace CryptoTracker.Import
         protected override CsvConfiguration CreateCsvConfiguration()
             => new CsvConfiguration(new CultureInfo("en-US"))
             {
-                Delimiter = ";"
+                Delimiter = ";",
+                HeaderValidated = null,
+                MissingFieldFound = null,
             };
 
         protected override async Task OnImport(ImportArgs args, IEnumerable<BitcoinDeTransaction> records)

--- a/src/CryptoTracker/CryptoTracker/Import/BitpandaTransactionImporter.cs
+++ b/src/CryptoTracker/CryptoTracker/Import/BitpandaTransactionImporter.cs
@@ -69,7 +69,7 @@ namespace CryptoTracker.Import
                     var sellTrade = new CryptoTrade
                     {
                         Wallet = args.Wallet,
-                        DateTime = record.Timestamp,
+                        DateTime = record.Timestamp.DateTime,
                         Symbol = record.TransactionType.Equals("buy", StringComparison.OrdinalIgnoreCase) ? record.Fiat : record.Asset,
                         OpositeSymbol = record.TransactionType.Equals("buy", StringComparison.OrdinalIgnoreCase) ? record.Asset : record.Fiat,
                         TradeType = TradeType.Sell,
@@ -83,7 +83,7 @@ namespace CryptoTracker.Import
                     var buyTrade = new CryptoTrade
                     {
                         Wallet = args.Wallet,
-                        DateTime = record.Timestamp,
+                        DateTime = record.Timestamp.DateTime,
                         Symbol = record.TransactionType.Equals("sell", StringComparison.OrdinalIgnoreCase) ? record.Fiat : record.Asset,
                         OpositeSymbol = record.TransactionType.Equals("sell", StringComparison.OrdinalIgnoreCase) ? record.Asset : record.Fiat,
                         TradeType = TradeType.Buy,
@@ -107,7 +107,7 @@ namespace CryptoTracker.Import
                     {
                         TransactionType = record.TransactionType == "deposit" ? TransactionType.Receive : TransactionType.Send,
                         Wallet = args.Wallet,
-                        DateTime = record.Timestamp,
+                        DateTime = record.Timestamp.DateTime,
                         Symbol = record.Asset,
                         Quantity = record.AmountAsset.GetValueOrDefault() + record.Fee.GetValueOrDefault(),
                         Fee = record.Fee.GetValueOrDefault(),

--- a/src/CryptoTracker/CryptoTracker/Import/Objects/BitpandaTransaction.cs
+++ b/src/CryptoTracker/CryptoTracker/Import/Objects/BitpandaTransaction.cs
@@ -24,7 +24,7 @@ namespace CryptoTracker.Import.Objects
         /// Datum in ISO 8601 und CET
         /// </summary>
         [Name("Timestamp", "Date")]
-        public DateTime Timestamp { get; set; }
+        public DateTimeOffset Timestamp { get; set; }
 
         /// <summary>
         /// deposit, withdrawal, buy, sell
@@ -91,12 +91,12 @@ namespace CryptoTracker.Import.Objects
         public decimal? Fee { get; set; }
 
         [Name("Fee asset")]
-        public decimal? FeeAsset { get; set; }
+        public string FeeAsset { get; set; } = string.Empty;
 
         public decimal? Spread { get; set; }
 
         [Name("Spread Currency")]
-        public decimal? SpreadCurrency { get; set; }
+        public string SpreadCurrency { get; set; } = string.Empty;
 
         [Name("Tax Fiat")]
         public decimal? TaxFiat { get; set; }


### PR DESCRIPTION
## Summary
- relax header validation for Bitcoin.de importer
- parse Bitpanda timestamps correctly and fix wrong property types
- adjust importer to use local datetime from timestamp

## Testing
- `dotnet test`