### PR TITLE
Integrate Blazorise layout and grids

### DIFF
--- a/src/CryptoTracker/CryptoTracker.Client/CryptoTracker.Client.csproj
+++ b/src/CryptoTracker/CryptoTracker.Client/CryptoTracker.Client.csproj
@@ -12,5 +12,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="9.0.5" />
     <PackageReference Include="Microsoft.Extensions.Localization" Version="9.0.5" />
+    <PackageReference Include="Blazorise" Version="1.1.0" />
+    <PackageReference Include="Blazorise.Bootstrap5" Version="1.1.0" />
+    <PackageReference Include="Blazorise.Icons.FontAwesome" Version="1.1.0" />
   </ItemGroup>
 </Project>

--- a/src/CryptoTracker/CryptoTracker.Client/Pages/Bilanzen.razor
+++ b/src/CryptoTracker/CryptoTracker.Client/Pages/Bilanzen.razor
@@ -18,25 +18,13 @@ else if (Balances != null)
     foreach (var balance in Balances)
     {
         <h5 class="mt-3">@balance.Platform</h5>
-        <table class="table table-striped">
-            <thead>
-                <tr>
-                    <th>Symbol</th>
-                    <th>Menge</th>
-                    <th>Wert in EUR</th>
-                </tr>
-            </thead>
-            <tbody>
-            @foreach (var asset in balance.Assets)
-            {
-                <tr>
-                    <td>@asset.Symbol</td>
-                    <td>@asset.Amount</td>
-                    <td>@string.Format("{0:F2}", asset.EuroValue)</td>
-                </tr>
-            }
-            </tbody>
-        </table>
+        <DataGrid TItem="AssetBalanceDTO" Data="balance.Assets" Sortable="true" Filterable="true" Resizable="true" ShowPager="false">
+            <DataGridColumns>
+                <DataGridColumn TItem="AssetBalanceDTO" Field="@nameof(AssetBalanceDTO.Symbol)" Caption="Symbol" />
+                <DataGridColumn TItem="AssetBalanceDTO" Field="@nameof(AssetBalanceDTO.Amount)" Caption="Menge" />
+                <DataGridColumn TItem="AssetBalanceDTO" Field="@nameof(AssetBalanceDTO.EuroValue)" Caption="Wert in EUR" />
+            </DataGridColumns>
+        </DataGrid>
     }
 }
 

--- a/src/CryptoTracker/CryptoTracker.Client/Pages/Overview.razor
+++ b/src/CryptoTracker/CryptoTracker.Client/Pages/Overview.razor
@@ -44,34 +44,16 @@ else
     </div>
 
     <div class="mt-3">
-        <table class="table table-striped">
-            <thead>
-                <tr>
-                    <th>DateTime</th>
-                    <th>FlowType</th>
-                    <th>FlowDirection</th>
-                    <th>SourceWallet</th>
-                    <th>TargetWallet</th>
-                    <th>FlowAmount</th>
-                </tr>
-            </thead>
-            <tbody>
-                @if (Flows != null)
-                {
-                    foreach (var flow in Flows)
-                    {
-                        <tr>
-                            <td>@flow.DateTime</td>
-                            <td>@flow.FlowType</td>
-                            <td>@flow.FlowDirection</td>
-                            <td>@flow.SourceWallet</td>
-                            <td>@flow.TargetWallet</td>
-                            <td>@flow.FlowAmount</td>
-                        </tr>
-                    }
-                }
-            </tbody>
-        </table>
+        <DataGrid TItem="FlowDTO" Data="Flows" Sortable="true" Filterable="true" Resizable="true" ShowPager="false">
+            <DataGridColumns>
+                <DataGridColumn TItem="FlowDTO" Field="@nameof(FlowDTO.DateTime)" Caption="DateTime" />
+                <DataGridColumn TItem="FlowDTO" Field="@nameof(FlowDTO.FlowType)" Caption="FlowType" />
+                <DataGridColumn TItem="FlowDTO" Field="@nameof(FlowDTO.FlowDirection)" Caption="FlowDirection" />
+                <DataGridColumn TItem="FlowDTO" Field="@nameof(FlowDTO.SourceWallet)" Caption="SourceWallet" />
+                <DataGridColumn TItem="FlowDTO" Field="@nameof(FlowDTO.TargetWallet)" Caption="TargetWallet" />
+                <DataGridColumn TItem="FlowDTO" Field="@nameof(FlowDTO.FlowAmount)" Caption="FlowAmount" />
+            </DataGridColumns>
+        </DataGrid>
     </div>
 
     <div class="mt-3">

--- a/src/CryptoTracker/CryptoTracker.Client/Pages/Wallets.razor
+++ b/src/CryptoTracker/CryptoTracker.Client/Pages/Wallets.razor
@@ -13,26 +13,17 @@
     <button class="btn btn-secondary mt-2" @onclick="NewWallet">Neu</button>
 </div>
 
-<table class="table table-striped">
-    <thead>
-        <tr>
-            <th>Name</th>
-            <th></th>
-        </tr>
-    </thead>
-    <tbody>
-        @foreach (var w in WalletsList)
-        {
-            <tr>
-                <td>@w.Name</td>
-                <td>
-                    <button class="btn btn-sm btn-secondary me-1" @onclick="(() => Edit(w))">Ändern</button>
-                    <button class="btn btn-sm btn-danger" @onclick="(() => Delete(w.Id))">Löschen</button>
-                </td>
-            </tr>
-        }
-    </tbody>
-</table>
+<DataGrid TItem="WalletInfoDTO" Data="WalletsList" Sortable="true" Filterable="true" Resizable="true" ShowPager="false">
+    <DataGridColumns>
+        <DataGridColumn TItem="WalletInfoDTO" Field="@nameof(WalletInfoDTO.Name)" Caption="Name" />
+        <DataGridTemplateColumn TItem="WalletInfoDTO">
+            <Template Context="w">
+                <button class="btn btn-sm btn-secondary me-1" @onclick="(() => Edit(w))">Ändern</button>
+                <button class="btn btn-sm btn-danger" @onclick="(() => Delete(w.Id))">Löschen</button>
+            </Template>
+        </DataGridTemplateColumn>
+    </DataGridColumns>
+</DataGrid>
 
 @if (ErrorMessage != null)
 {

--- a/src/CryptoTracker/CryptoTracker.Client/Program.cs
+++ b/src/CryptoTracker/CryptoTracker.Client/Program.cs
@@ -1,12 +1,23 @@
 using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
 using System.Globalization;
+using Blazorise;
+using Blazorise.Bootstrap5;
+using Blazorise.Icons.FontAwesome;
 
 var builder = WebAssemblyHostBuilder.CreateDefault(args);
 builder.Services.AddScoped(sp => new HttpClient { BaseAddress = new Uri(builder.HostEnvironment.BaseAddress) });
 
 builder.Services.AddLocalization(options => options.ResourcesPath = "Resources");
+builder.Services.AddBlazorise(options => { options.Immediate = true; })
+    .AddBootstrap5Providers()
+    .AddFontAwesomeIcons();
 
 var culture = new CultureInfo("de");
 CultureInfo.DefaultThreadCurrentCulture = culture;
 CultureInfo.DefaultThreadCurrentUICulture = culture;
-await builder.Build().RunAsync();
+
+var host = builder.Build();
+
+await host.Services.UseBootstrap5Providers().UseFontAwesomeIcons();
+
+await host.RunAsync();

--- a/src/CryptoTracker/CryptoTracker.Client/_Imports.razor
+++ b/src/CryptoTracker/CryptoTracker.Client/_Imports.razor
@@ -8,3 +8,5 @@
 @using Microsoft.JSInterop
 @using CryptoTracker.Client
 @using Microsoft.Extensions.Localization
+@using Blazorise
+@using Blazorise.DataGrid

--- a/src/CryptoTracker/CryptoTracker/Components/App.razor
+++ b/src/CryptoTracker/CryptoTracker/Components/App.razor
@@ -6,6 +6,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <base href="/" />
     <link rel="stylesheet" href="bootstrap/bootstrap.min.css" />
+    <link rel="stylesheet" href="_content/Blazorise/blazorise.css" />
+    <link rel="stylesheet" href="_content/Blazorise.Bootstrap5/blazorise.bootstrap5.css" />
+    <link rel="stylesheet" href="_content/Blazorise.Icons.FontAwesome/blazorise.icons.fontawesome.css" />
     <link rel="stylesheet" href="app.css" />
     <link rel="stylesheet" href="CryptoTracker.styles.css" />
     <link rel="icon" type="image/png" href="favicon.png" />
@@ -14,6 +17,7 @@
 
 <body>
     <Routes />
+    <script src="_content/Blazorise/blazorise.js"></script>
     <script src="_framework/blazor.web.js"></script>
 </body>
 

--- a/src/CryptoTracker/CryptoTracker/Components/Layout/MainLayout.razor
+++ b/src/CryptoTracker/CryptoTracker/Components/Layout/MainLayout.razor
@@ -1,20 +1,18 @@
 ﻿@inherits LayoutComponentBase
 
-<div class="page">
-    <div class="sidebar">
+<Layout>
+    <LayoutSider Width="250px" Background="Background.Dark">
         <NavMenu />
-    </div>
-
-    <main>
-        <div class="top-row px-4">
+    </LayoutSider>
+    <Layout>
+        <LayoutHeader Class="bg-dark text-white px-4">
             <h1 class="logo">CryptoTracker</h1>
-        </div>
-
-        <article class="content px-4">
+        </LayoutHeader>
+        <LayoutContent Class="p-4">
             @Body
-        </article>
-    </main>
-</div>
+        </LayoutContent>
+    </Layout>
+</Layout>
 
 <div id="blazor-error-ui">
     An unhandled error has occurred.

--- a/src/CryptoTracker/CryptoTracker/Components/Layout/NavMenu.razor
+++ b/src/CryptoTracker/CryptoTracker/Components/Layout/NavMenu.razor
@@ -1,84 +1,32 @@
-﻿<div class="top-row ps-3 navbar navbar-dark">
-    <div class="container-fluid">
-        <a class="navbar-brand" href="">CryptoTracker</a>
-    </div>
-</div>
-
-<input type="checkbox" title="Navigation menu" class="navbar-toggler" />
-
-<div class="nav-scrollable" onclick="document.querySelector('.navbar-toggler').click()">
-    <nav class="flex-column">
-        <div class="nav-item px-3">
-            <NavLink class="nav-link" href="" Match="NavLinkMatch.All">
-                <span class="bi bi-house-door-fill-nav-menu" aria-hidden="true"></span> Überblick
-            </NavLink>
-        </div>
-
-        <div class="nav-item px-3">
-            <NavLink class="nav-link" href="bilanzen">
-                <span class="bi bi-cash-stack-nav-menu" aria-hidden="true"></span> Bilanzen
-            </NavLink>
-        </div>
-
-        <div class="nav-item px-3">
-            <NavLink class="nav-link" href="wallets">
-                <span class="bi bi-wallet2-nav-menu" aria-hidden="true"></span> Wallets
-            </NavLink>
-        </div>
-
-        <div class="nav-item px-3">
-            <NavLink class="nav-link" href="import">
-                <span class="bi bi-plus-square-fill-nav-menu" aria-hidden="true"></span> Import
-            </NavLink>
-
-            <div class="ms-3">
-                <div class="nav-item px-3">
-                    <NavLink class="nav-link" href="import/binance-deposit">
-                        <span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> Binance Deposit
-                    </NavLink>
-                </div>
-                <div class="nav-item px-3">
-                    <NavLink class="nav-link" href="import/binance-withdrawal">
-                        <span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> Binance Withdrawal
-                    </NavLink>
-                </div>
-                <div class="nav-item px-3">
-                    <NavLink class="nav-link" href="import/binance-trade">
-                        <span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> Binance Trade
-                    </NavLink>
-                </div>
-                <div class="nav-item px-3">
-                    <NavLink class="nav-link" href="import/bitcoinde-transactions">
-                        <span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> Bitcoin.de Transactions
-                    </NavLink>
-                </div>
-                <div class="nav-item px-3">
-                    <NavLink class="nav-link" href="import/bitpanda-transactions">
-                        <span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> Bitpanda Transactions
-                    </NavLink>
-                </div>
-                <div class="nav-item px-3">
-                    <NavLink class="nav-link" href="import/metamask-transactions">
-                        <span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> Metamask Transactions
-                    </NavLink>
-                </div>
-                <div class="nav-item px-3">
-                    <NavLink class="nav-link" href="import/metamask-trades">
-                        <span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> Metamask Trades
-                    </NavLink>
-                </div>
-                <div class="nav-item px-3">
-                    <NavLink class="nav-link" href="import/okx-deposit">
-                        <span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> Okx Deposit
-                    </NavLink>
-                </div>
-                <div class="nav-item px-3">
-                    <NavLink class="nav-link" href="import/okx-trade">
-                        <span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> Okx Trade
-                    </NavLink>
-                </div>
-            </div>
-        </div>
-    </nav>
-</div>
-
+<Bar Mode="BarMode.Vertical" Class="mb-4" Background="Background.Dark" ThemeContrast="ThemeContrast.Dark">
+    <BarBrand>
+        <BarItem>
+            <BarLink To="">CryptoTracker</BarLink>
+        </BarItem>
+    </BarBrand>
+    <BarMenu>
+        <BarItem>
+            <BarLink To="" Match="NavLinkMatch.All">Überblick</BarLink>
+        </BarItem>
+        <BarItem>
+            <BarLink To="bilanzen">Bilanzen</BarLink>
+        </BarItem>
+        <BarItem>
+            <BarLink To="wallets">Wallets</BarLink>
+        </BarItem>
+        <BarDropdown>
+            <BarLink To="import">Import</BarLink>
+            <BarDropdownMenu Class="ms-3">
+                <BarItem><BarLink To="import/binance-deposit">Binance Deposit</BarLink></BarItem>
+                <BarItem><BarLink To="import/binance-withdrawal">Binance Withdrawal</BarLink></BarItem>
+                <BarItem><BarLink To="import/binance-trade">Binance Trade</BarLink></BarItem>
+                <BarItem><BarLink To="import/bitcoinde-transactions">Bitcoin.de Transactions</BarLink></BarItem>
+                <BarItem><BarLink To="import/bitpanda-transactions">Bitpanda Transactions</BarLink></BarItem>
+                <BarItem><BarLink To="import/metamask-transactions">Metamask Transactions</BarLink></BarItem>
+                <BarItem><BarLink To="import/metamask-trades">Metamask Trades</BarLink></BarItem>
+                <BarItem><BarLink To="import/okx-deposit">Okx Deposit</BarLink></BarItem>
+                <BarItem><BarLink To="import/okx-trade">Okx Trade</BarLink></BarItem>
+            </BarDropdownMenu>
+        </BarDropdown>
+    </BarMenu>
+</Bar>

--- a/src/CryptoTracker/CryptoTracker/Components/_Imports.razor
+++ b/src/CryptoTracker/CryptoTracker/Components/_Imports.razor
@@ -10,3 +10,5 @@
 @using CryptoTracker.Client
 @using CryptoTracker.Components
 @using Microsoft.Extensions.Localization
+@using Blazorise
+@using Blazorise.DataGrid

--- a/src/CryptoTracker/CryptoTracker/CryptoTracker.csproj
+++ b/src/CryptoTracker/CryptoTracker/CryptoTracker.csproj
@@ -18,6 +18,9 @@
     </PackageReference>
     <PackageReference Include="Finance.NET" Version="1.0.7" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.21.0" />
+    <PackageReference Include="Blazorise" Version="1.1.0" />
+    <PackageReference Include="Blazorise.Bootstrap5" Version="1.1.0" />
+    <PackageReference Include="Blazorise.Icons.FontAwesome" Version="1.1.0" />
   </ItemGroup>
 
 </Project>

--- a/src/CryptoTracker/CryptoTracker/Startup.cs
+++ b/src/CryptoTracker/CryptoTracker/Startup.cs
@@ -5,6 +5,9 @@ using Microsoft.AspNetCore.Components;
 using CryptoTracker.Services;
 using Finance.Net;
 using Finance.Net.Extensions;
+using Blazorise;
+using Blazorise.Bootstrap5;
+using Blazorise.Icons.FontAwesome;
 
 namespace CryptoTracker
 {
@@ -33,6 +36,10 @@ namespace CryptoTracker
             services.AddRazorComponents()
                 .AddInteractiveServerComponents()
                 .AddInteractiveWebAssemblyComponents();
+
+            services.AddBlazorise(options => { options.Immediate = true; })
+                .AddBootstrap5Providers()
+                .AddFontAwesomeIcons();
 
             services.AddFinanceNet(new FinanceNetConfiguration()
             {
@@ -71,6 +78,10 @@ namespace CryptoTracker
 
             app.UseHttpsRedirection();
             app.UseStaticFiles();
+
+            app.ApplicationServices
+                .UseBootstrap5Providers()
+                .UseFontAwesomeIcons();
 
             app.UseRouting();
             app.UseAntiforgery();


### PR DESCRIPTION
## Summary
- integrate Blazorise packages in server and client projects
- hook Blazorise services in Startup and Program
- add Blazorise styles and scripts in App.razor
- recreate layout and navigation with Blazorise components
- replace bootstrap tables by Blazorise `DataGrid`

## Testing
- `dotnet build CryptoTracker.sln -c Release` *(fails: No route to host)*