### PR TITLE
Add CI on main and improve PR test reporting

### DIFF
--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -1,10 +1,11 @@
-name: PR Build and Test
+name: Main Build and Test
 
 on:
-  pull_request:
+  push:
+    branches: [ main ]
 
 jobs:
-  build-test:
+  build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -20,12 +21,25 @@ jobs:
       - name: Build
         run: dotnet build --configuration Release --no-restore
 
+  test:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up .NET
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: '9.0.x'
+
+      - name: Restore dependencies
+        run: dotnet restore
+
       - name: Test
         run: dotnet test --configuration Release \
           --logger "trx;LogFileName=test_results.trx" \
           --results-directory TestResults \
           --verbosity normal
-        continue-on-error: true
 
       - name: Summarize test results
         if: always()


### PR DESCRIPTION
## Summary
- improve PR workflow to store and summarize unit test results
- add CI workflow triggered on push to main branch with separate build/test jobs

## Testing
- `dotnet test --no-build --verbosity normal` *(fails: VSTestTask returned false)*