### PR TITLE
Add dependabot for NuGet packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "nuget"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10

--- a/README.md
+++ b/README.md
@@ -24,4 +24,8 @@ Features:
 - Finanzamtprotokoll
   - Spezielle für einen Asset-Ausgang
 
+Weitere Automatisierungen:
+- Abhängigkeiten werden wöchentlich mit [Dependabot](https://docs.github.com/de/code-security/dependabot/dependabot-version-updates/configuration-options-for-dependency-updates) geprüft und Updates
+  als Pull Request bereitgestellt.
+
 


### PR DESCRIPTION
## Summary
- add `.github/dependabot.yml` to automatically check for NuGet updates
- document Dependabot usage in README

## Testing
- `dotnet test` *(fails: `IServiceProvider` does not contain definition for `UseBootstrap5Providers`)*