### PR TITLE
Fix dotnet test multiline command

### DIFF
--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -36,10 +36,11 @@ jobs:
         run: dotnet restore
 
       - name: Test
-        run: dotnet test --configuration Release \
-          --logger "trx;LogFileName=test_results.trx" \
-          --results-directory TestResults \
-          --verbosity normal
+        run: |
+          dotnet test --configuration Release \
+            --logger "trx;LogFileName=test_results.trx" \
+            --results-directory TestResults \
+            --verbosity normal
 
       - name: Summarize test results
         if: always()

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -21,10 +21,11 @@ jobs:
         run: dotnet build --configuration Release --no-restore
 
       - name: Test
-        run: dotnet test --configuration Release \
-          --logger "trx;LogFileName=test_results.trx" \
-          --results-directory TestResults \
-          --verbosity normal
+        run: |
+          dotnet test --configuration Release \
+            --logger "trx;LogFileName=test_results.trx" \
+            --results-directory TestResults \
+            --verbosity normal
         continue-on-error: true
 
       - name: Summarize test results


### PR DESCRIPTION
## Summary
- fix dotnet test multiline command in main CI workflow
- fix the same command in PR CI workflow

## Testing
- `dotnet test --configuration Release --logger "trx;LogFileName=test_results.trx" --results-directory TestResults --verbosity normal`