### PR TITLE
Add wallet references to import entries

### DIFF
--- a/src/CryptoTracker.Client/Pages/ImportPages/ImportPageBase.razor
+++ b/src/CryptoTracker.Client/Pages/ImportPages/ImportPageBase.razor
@@ -7,7 +7,13 @@
 <h3>@Title</h3>
 
 <InputFile OnChange="HandleFileSelected" />
-<input class="form-control mt-2" @bind="WalletName" placeholder="Wallet Name" />
+<select class="form-select mt-2" @bind="WalletName">
+    <option value="">Wallet wählen</option>
+    @foreach (var w in Wallets)
+    {
+        <option value="@w.Name">@w.Name</option>
+    }
+</select>
 <button class="btn btn-primary mt-2" @onclick="Upload">Importieren</button>
 
 @if (Entries == null)
@@ -55,6 +61,7 @@ else if (Entries.Count > 0)
     private string WalletName { get; set; } = string.Empty;
     private string? ErrorMessage { get; set; }
     private const long MAX_REQUEST_SIZE = 1024 * 1024 * 100;
+    private IList<WalletInfoDTO> Wallets { get; set; } = new List<WalletInfoDTO>();
 
     [Parameter] public ImportDocumentType DocumentType { get; set; }
 
@@ -62,6 +69,7 @@ else if (Entries.Count > 0)
     {
         await base.OnInitializedAsync();
         await LoadData();
+        Wallets = await HttpClient.GetFromJsonAsync<IList<WalletInfoDTO>>("api/Wallet/GetWalletInfos") ?? new List<WalletInfoDTO>();
     }
 
     private Task HandleFileSelected(InputFileChangeEventArgs e)

--- a/src/CryptoTracker/Controllers/ImportEntriesController.cs
+++ b/src/CryptoTracker/Controllers/ImportEntriesController.cs
@@ -1,4 +1,4 @@
-using CryptoTracker.Import.Objects;
+using CryptoTracker.Entities.Import;
 using CryptoTracker.Shared;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;

--- a/src/CryptoTracker/DbContext/CryptoTrackerDbContext.cs
+++ b/src/CryptoTracker/DbContext/CryptoTrackerDbContext.cs
@@ -1,5 +1,5 @@
 ﻿using CryptoTracker.Entities;
-using CryptoTracker.Import.Objects;
+using CryptoTracker.Entities.Import;
 using Microsoft.EntityFrameworkCore;
 
 namespace CryptoTracker
@@ -9,15 +9,15 @@ namespace CryptoTracker
         public DbSet<CryptoTransaction> CryptoTransactions { get; set; }
         public DbSet<CryptoTrade> CryptoTrades { get; set; }
         public DbSet<Wallet> Wallets { get; set; }
-        public DbSet<BinanceDeposit> BinanceDeposits { get; set; }
-        public DbSet<BinanceWithdrawal> BinanceWithdrawals { get; set; }
-        public DbSet<BinanceTrade> BinanceTrades { get; set; }
-        public DbSet<BitcoinDeTransaction> BitcoinDeTransactions { get; set; }
-        public DbSet<BitpandaTransaction> BitpandaTransactions { get; set; }
-        public DbSet<MetamaskTrade> MetamaskTrades { get; set; }
-        public DbSet<MetamaskTransaction> MetamaskTransactions { get; set; }
-        public DbSet<OkxDeposit> OkxDeposits { get; set; }
-        public DbSet<OkxTrade> OkxTrades { get; set; }
+        public DbSet<BinanceDepositEntity> BinanceDeposits { get; set; }
+        public DbSet<BinanceWithdrawalEntity> BinanceWithdrawals { get; set; }
+        public DbSet<BinanceTradeEntity> BinanceTrades { get; set; }
+        public DbSet<BitcoinDeTransactionEntity> BitcoinDeTransactions { get; set; }
+        public DbSet<BitpandaTransactionEntity> BitpandaTransactions { get; set; }
+        public DbSet<MetamaskTradeEntity> MetamaskTrades { get; set; }
+        public DbSet<MetamaskTransactionEntity> MetamaskTransactions { get; set; }
+        public DbSet<OkxDepositEntity> OkxDeposits { get; set; }
+        public DbSet<OkxTradeEntity> OkxTrades { get; set; }
 
         public CryptoTrackerDbContext(DbContextOptions<CryptoTrackerDbContext> options) : base(options)
         {
@@ -55,15 +55,15 @@ namespace CryptoTracker
                 .WithMany()
                 .HasForeignKey(c => c.WalletId);
 
-            modelBuilder.Entity<BinanceDeposit>().HasKey(b => b.Id);
-            modelBuilder.Entity<BinanceWithdrawal>().HasKey(b => b.Id);
-            modelBuilder.Entity<BinanceTrade>().HasKey(b => b.Id);
-            modelBuilder.Entity<BitcoinDeTransaction>().HasKey(b => b.Id);
-            modelBuilder.Entity<BitpandaTransaction>().HasKey(b => b.Id);
-            modelBuilder.Entity<MetamaskTrade>().HasKey(b => b.Id);
-            modelBuilder.Entity<MetamaskTransaction>().HasKey(b => b.Id);
-            modelBuilder.Entity<OkxDeposit>().HasKey(b => b.Id);
-            modelBuilder.Entity<OkxTrade>().HasKey(b => b.Id);
+            modelBuilder.Entity<BinanceDepositEntity>().HasKey(b => b.Id);
+            modelBuilder.Entity<BinanceWithdrawalEntity>().HasKey(b => b.Id);
+            modelBuilder.Entity<BinanceTradeEntity>().HasKey(b => b.Id);
+            modelBuilder.Entity<BitcoinDeTransactionEntity>().HasKey(b => b.Id);
+            modelBuilder.Entity<BitpandaTransactionEntity>().HasKey(b => b.Id);
+            modelBuilder.Entity<MetamaskTradeEntity>().HasKey(b => b.Id);
+            modelBuilder.Entity<MetamaskTransactionEntity>().HasKey(b => b.Id);
+            modelBuilder.Entity<OkxDepositEntity>().HasKey(b => b.Id);
+            modelBuilder.Entity<OkxTradeEntity>().HasKey(b => b.Id);
 
             modelBuilder.Entity<CryptoTrade>()
                 .Property(c => c.Price)

--- a/src/CryptoTracker/Entities/Import/BinanceDepositEntity.cs
+++ b/src/CryptoTracker/Entities/Import/BinanceDepositEntity.cs
@@ -1,0 +1,17 @@
+namespace CryptoTracker.Entities.Import;
+
+public class BinanceDepositEntity
+{
+    public int Id { get; set; }
+    public int WalletId { get; set; }
+    public Wallet Wallet { get; set; } = null!;
+
+    public DateTimeOffset Date { get; set; }
+    public string Coin { get; set; } = string.Empty;
+    public string Network { get; set; } = string.Empty;
+    public decimal Amount { get; set; }
+    public decimal TransactionFee { get; set; }
+    public string Address { get; set; } = string.Empty;
+    public string TXID { get; set; } = string.Empty;
+    public string Comment { get; set; } = string.Empty;
+}

--- a/src/CryptoTracker/Entities/Import/BinanceTradeEntity.cs
+++ b/src/CryptoTracker/Entities/Import/BinanceTradeEntity.cs
@@ -1,0 +1,16 @@
+namespace CryptoTracker.Entities.Import;
+
+public class BinanceTradeEntity
+{
+    public int Id { get; set; }
+    public int WalletId { get; set; }
+    public Wallet Wallet { get; set; } = null!;
+
+    public DateTimeOffset Date { get; set; }
+    public string Pair { get; set; } = string.Empty;
+    public string Side { get; set; } = string.Empty;
+    public decimal Price { get; set; }
+    public string Executed { get; set; } = string.Empty;
+    public string Amount { get; set; } = string.Empty;
+    public string Fee { get; set; } = string.Empty;
+}

--- a/src/CryptoTracker/Entities/Import/BinanceWithdrawalEntity.cs
+++ b/src/CryptoTracker/Entities/Import/BinanceWithdrawalEntity.cs
@@ -1,0 +1,17 @@
+namespace CryptoTracker.Entities.Import;
+
+public class BinanceWithdrawalEntity
+{
+    public int Id { get; set; }
+    public int WalletId { get; set; }
+    public Wallet Wallet { get; set; } = null!;
+
+    public DateTimeOffset Date { get; set; }
+    public string Coin { get; set; } = string.Empty;
+    public string Network { get; set; } = string.Empty;
+    public decimal Amount { get; set; }
+    public decimal TransactionFee { get; set; }
+    public string Address { get; set; } = string.Empty;
+    public string TXID { get; set; } = string.Empty;
+    public string Comment { get; set; } = string.Empty;
+}

--- a/src/CryptoTracker/Entities/Import/BitcoinDeTransactionEntity.cs
+++ b/src/CryptoTracker/Entities/Import/BitcoinDeTransactionEntity.cs
@@ -1,0 +1,25 @@
+namespace CryptoTracker.Entities.Import;
+
+public class BitcoinDeTransactionEntity
+{
+    public int Id { get; set; }
+    public int WalletId { get; set; }
+    public Wallet Wallet { get; set; } = null!;
+
+    public DateTime Datum { get; set; }
+    public string Typ { get; set; } = string.Empty;
+    public string Waehrung { get; set; } = string.Empty;
+    public string Referenz { get; set; } = string.Empty;
+    public string Adresse { get; set; } = string.Empty;
+    public decimal? Kurs { get; set; }
+    public string EinheitKurs { get; set; } = string.Empty;
+    public decimal? CryptoVorGebuehr { get; set; }
+    public decimal? MengeVorGebuehr { get; set; }
+    public string EinheitMengeVorGebuehr { get; set; } = string.Empty;
+    public decimal? CryptoNachGebuehr { get; set; }
+    public decimal? MengeNachGebuehr { get; set; }
+    public string EinheitMengeNachGebuehr { get; set; } = string.Empty;
+    public decimal ZuAbgang { get; set; }
+    public decimal Kontostand { get; set; }
+    public string Kommentar { get; set; } = string.Empty;
+}

--- a/src/CryptoTracker/Entities/Import/BitpandaTransactionEntity.cs
+++ b/src/CryptoTracker/Entities/Import/BitpandaTransactionEntity.cs
@@ -1,0 +1,28 @@
+namespace CryptoTracker.Entities.Import;
+
+public class BitpandaTransactionEntity
+{
+    public int Id { get; set; }
+    public int WalletId { get; set; }
+    public Wallet Wallet { get; set; } = null!;
+
+    public string TransactionId { get; set; } = string.Empty;
+    public DateTimeOffset Timestamp { get; set; }
+    public string TransactionType { get; set; } = string.Empty;
+    public string InOut { get; set; } = string.Empty;
+    public decimal? AmountFiat { get; set; }
+    public string Fiat { get; set; } = string.Empty;
+    public decimal? AmountAsset { get; set; }
+    public string Asset { get; set; } = string.Empty;
+    public decimal? AssetMarketPrice { get; set; }
+    public string AssetMarketPriceCurrency { get; set; } = string.Empty;
+    public string AssetClass { get; set; } = string.Empty;
+    public int? ProductID { get; set; }
+    public decimal? Fee { get; set; }
+    public string FeeAsset { get; set; } = string.Empty;
+    public decimal? Spread { get; set; }
+    public string SpreadCurrency { get; set; } = string.Empty;
+    public decimal? TaxFiat { get; set; }
+    public string Address { get; set; } = string.Empty;
+    public string Comment { get; set; } = string.Empty;
+}

--- a/src/CryptoTracker/Entities/Import/MetamaskTradeEntity.cs
+++ b/src/CryptoTracker/Entities/Import/MetamaskTradeEntity.cs
@@ -1,0 +1,17 @@
+namespace CryptoTracker.Entities.Import;
+
+public class MetamaskTradeEntity
+{
+    public int Id { get; set; }
+    public int WalletId { get; set; }
+    public Wallet Wallet { get; set; } = null!;
+
+    public DateTimeOffset Date { get; set; }
+    public string Pair { get; set; } = string.Empty;
+    public string Side { get; set; } = string.Empty;
+    public string Price { get; set; } = string.Empty;
+    public string Executed { get; set; } = string.Empty;
+    public string Amount { get; set; } = string.Empty;
+    public string Fee { get; set; } = string.Empty;
+    public string Tradingplatform { get; set; } = string.Empty;
+}

--- a/src/CryptoTracker/Entities/Import/MetamaskTransactionEntity.cs
+++ b/src/CryptoTracker/Entities/Import/MetamaskTransactionEntity.cs
@@ -1,0 +1,20 @@
+namespace CryptoTracker.Entities.Import;
+
+public class MetamaskTransactionEntity
+{
+    public int Id { get; set; }
+    public int WalletId { get; set; }
+    public Wallet Wallet { get; set; } = null!;
+
+    public DateTimeOffset Date { get; set; }
+    public string Type { get; set; } = string.Empty;
+    public string Hash { get; set; } = string.Empty;
+    public string From { get; set; } = string.Empty;
+    public string To { get; set; } = string.Empty;
+    public string Value { get; set; } = string.Empty;
+    public string ValueInUSD { get; set; } = string.Empty;
+    public string TransactionFee { get; set; } = string.Empty;
+    public string TransactionFeeInUSD { get; set; } = string.Empty;
+    public string GasPrice { get; set; } = string.Empty;
+    public string GasLimit { get; set; } = string.Empty;
+}

--- a/src/CryptoTracker/Entities/Import/OkxDepositEntity.cs
+++ b/src/CryptoTracker/Entities/Import/OkxDepositEntity.cs
@@ -1,0 +1,17 @@
+namespace CryptoTracker.Entities.Import;
+
+public class OkxDepositEntity
+{
+    public int Id { get; set; }
+    public int WalletId { get; set; }
+    public Wallet Wallet { get; set; } = null!;
+
+    public DateTimeOffset Date { get; set; }
+    public string Coin { get; set; } = string.Empty;
+    public string Network { get; set; } = string.Empty;
+    public decimal Amount { get; set; }
+    public decimal TransactionFee { get; set; }
+    public string Address { get; set; } = string.Empty;
+    public string TXID { get; set; } = string.Empty;
+    public string Comment { get; set; } = string.Empty;
+}

--- a/src/CryptoTracker/Entities/Import/OkxTradeEntity.cs
+++ b/src/CryptoTracker/Entities/Import/OkxTradeEntity.cs
@@ -1,0 +1,14 @@
+namespace CryptoTracker.Entities.Import;
+
+public class OkxTradeEntity
+{
+    public int Id { get; set; }
+    public int WalletId { get; set; }
+    public Wallet Wallet { get; set; } = null!;
+
+    public DateTimeOffset Date { get; set; }
+    public string Pair { get; set; } = string.Empty;
+    public string Side { get; set; } = string.Empty;
+    public string Price { get; set; } = string.Empty;
+    public decimal Executed { get; set; }
+}

--- a/src/CryptoTracker/Migrations/20250524212355_ImportEntitiesWithWallet.Designer.cs
+++ b/src/CryptoTracker/Migrations/20250524212355_ImportEntitiesWithWallet.Designer.cs
@@ -4,6 +4,7 @@ using CryptoTracker;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace CryptoTracker.Migrations
 {
     [DbContext(typeof(CryptoTrackerDbContext))]
-    partial class CryptoTrackerDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250524212355_ImportEntitiesWithWallet")]
+    partial class ImportEntitiesWithWallet
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/CryptoTracker/Migrations/20250524212355_ImportEntitiesWithWallet.cs
+++ b/src/CryptoTracker/Migrations/20250524212355_ImportEntitiesWithWallet.cs
@@ -1,0 +1,470 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace CryptoTracker.Migrations
+{
+    /// <inheritdoc />
+    public partial class ImportEntitiesWithWallet : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Amount",
+                table: "MetamaskTransactions");
+
+            migrationBuilder.RenameColumn(
+                name: "Kommentar",
+                table: "OkxDeposits",
+                newName: "TXID");
+
+            migrationBuilder.RenameColumn(
+                name: "Typ",
+                table: "MetamaskTransactions",
+                newName: "ValueInUSD");
+
+            migrationBuilder.RenameColumn(
+                name: "Network",
+                table: "MetamaskTransactions",
+                newName: "Value");
+
+            migrationBuilder.RenameColumn(
+                name: "Kommentar",
+                table: "MetamaskTransactions",
+                newName: "Type");
+
+            migrationBuilder.RenameColumn(
+                name: "Datum",
+                table: "MetamaskTransactions",
+                newName: "Date");
+
+            migrationBuilder.RenameColumn(
+                name: "Coin",
+                table: "MetamaskTransactions",
+                newName: "TransactionFeeInUSD");
+
+            migrationBuilder.AddColumn<int>(
+                name: "WalletId",
+                table: "OkxTrades",
+                type: "int",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<string>(
+                name: "Comment",
+                table: "OkxDeposits",
+                type: "nvarchar(max)",
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AddColumn<decimal>(
+                name: "TransactionFee",
+                table: "OkxDeposits",
+                type: "decimal(18,2)",
+                nullable: false,
+                defaultValue: 0m);
+
+            migrationBuilder.AddColumn<int>(
+                name: "WalletId",
+                table: "OkxDeposits",
+                type: "int",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "TransactionFee",
+                table: "MetamaskTransactions",
+                type: "nvarchar(max)",
+                nullable: false,
+                oldClrType: typeof(decimal),
+                oldType: "decimal(18,2)");
+
+            migrationBuilder.AddColumn<string>(
+                name: "From",
+                table: "MetamaskTransactions",
+                type: "nvarchar(max)",
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AddColumn<string>(
+                name: "GasLimit",
+                table: "MetamaskTransactions",
+                type: "nvarchar(max)",
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AddColumn<string>(
+                name: "GasPrice",
+                table: "MetamaskTransactions",
+                type: "nvarchar(max)",
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AddColumn<string>(
+                name: "Hash",
+                table: "MetamaskTransactions",
+                type: "nvarchar(max)",
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AddColumn<string>(
+                name: "To",
+                table: "MetamaskTransactions",
+                type: "nvarchar(max)",
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AddColumn<int>(
+                name: "WalletId",
+                table: "MetamaskTransactions",
+                type: "int",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<int>(
+                name: "WalletId",
+                table: "MetamaskTrades",
+                type: "int",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<int>(
+                name: "WalletId",
+                table: "BitpandaTransactions",
+                type: "int",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<int>(
+                name: "WalletId",
+                table: "BitcoinDeTransactions",
+                type: "int",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<int>(
+                name: "WalletId",
+                table: "BinanceWithdrawals",
+                type: "int",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<int>(
+                name: "WalletId",
+                table: "BinanceTrades",
+                type: "int",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<int>(
+                name: "WalletId",
+                table: "BinanceDeposits",
+                type: "int",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_OkxTrades_WalletId",
+                table: "OkxTrades",
+                column: "WalletId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_OkxDeposits_WalletId",
+                table: "OkxDeposits",
+                column: "WalletId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_MetamaskTransactions_WalletId",
+                table: "MetamaskTransactions",
+                column: "WalletId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_MetamaskTrades_WalletId",
+                table: "MetamaskTrades",
+                column: "WalletId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_BitpandaTransactions_WalletId",
+                table: "BitpandaTransactions",
+                column: "WalletId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_BitcoinDeTransactions_WalletId",
+                table: "BitcoinDeTransactions",
+                column: "WalletId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_BinanceWithdrawals_WalletId",
+                table: "BinanceWithdrawals",
+                column: "WalletId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_BinanceTrades_WalletId",
+                table: "BinanceTrades",
+                column: "WalletId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_BinanceDeposits_WalletId",
+                table: "BinanceDeposits",
+                column: "WalletId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_BinanceDeposits_Wallets_WalletId",
+                table: "BinanceDeposits",
+                column: "WalletId",
+                principalTable: "Wallets",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_BinanceTrades_Wallets_WalletId",
+                table: "BinanceTrades",
+                column: "WalletId",
+                principalTable: "Wallets",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_BinanceWithdrawals_Wallets_WalletId",
+                table: "BinanceWithdrawals",
+                column: "WalletId",
+                principalTable: "Wallets",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_BitcoinDeTransactions_Wallets_WalletId",
+                table: "BitcoinDeTransactions",
+                column: "WalletId",
+                principalTable: "Wallets",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_BitpandaTransactions_Wallets_WalletId",
+                table: "BitpandaTransactions",
+                column: "WalletId",
+                principalTable: "Wallets",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_MetamaskTrades_Wallets_WalletId",
+                table: "MetamaskTrades",
+                column: "WalletId",
+                principalTable: "Wallets",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_MetamaskTransactions_Wallets_WalletId",
+                table: "MetamaskTransactions",
+                column: "WalletId",
+                principalTable: "Wallets",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_OkxDeposits_Wallets_WalletId",
+                table: "OkxDeposits",
+                column: "WalletId",
+                principalTable: "Wallets",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_OkxTrades_Wallets_WalletId",
+                table: "OkxTrades",
+                column: "WalletId",
+                principalTable: "Wallets",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_BinanceDeposits_Wallets_WalletId",
+                table: "BinanceDeposits");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_BinanceTrades_Wallets_WalletId",
+                table: "BinanceTrades");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_BinanceWithdrawals_Wallets_WalletId",
+                table: "BinanceWithdrawals");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_BitcoinDeTransactions_Wallets_WalletId",
+                table: "BitcoinDeTransactions");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_BitpandaTransactions_Wallets_WalletId",
+                table: "BitpandaTransactions");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_MetamaskTrades_Wallets_WalletId",
+                table: "MetamaskTrades");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_MetamaskTransactions_Wallets_WalletId",
+                table: "MetamaskTransactions");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_OkxDeposits_Wallets_WalletId",
+                table: "OkxDeposits");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_OkxTrades_Wallets_WalletId",
+                table: "OkxTrades");
+
+            migrationBuilder.DropIndex(
+                name: "IX_OkxTrades_WalletId",
+                table: "OkxTrades");
+
+            migrationBuilder.DropIndex(
+                name: "IX_OkxDeposits_WalletId",
+                table: "OkxDeposits");
+
+            migrationBuilder.DropIndex(
+                name: "IX_MetamaskTransactions_WalletId",
+                table: "MetamaskTransactions");
+
+            migrationBuilder.DropIndex(
+                name: "IX_MetamaskTrades_WalletId",
+                table: "MetamaskTrades");
+
+            migrationBuilder.DropIndex(
+                name: "IX_BitpandaTransactions_WalletId",
+                table: "BitpandaTransactions");
+
+            migrationBuilder.DropIndex(
+                name: "IX_BitcoinDeTransactions_WalletId",
+                table: "BitcoinDeTransactions");
+
+            migrationBuilder.DropIndex(
+                name: "IX_BinanceWithdrawals_WalletId",
+                table: "BinanceWithdrawals");
+
+            migrationBuilder.DropIndex(
+                name: "IX_BinanceTrades_WalletId",
+                table: "BinanceTrades");
+
+            migrationBuilder.DropIndex(
+                name: "IX_BinanceDeposits_WalletId",
+                table: "BinanceDeposits");
+
+            migrationBuilder.DropColumn(
+                name: "WalletId",
+                table: "OkxTrades");
+
+            migrationBuilder.DropColumn(
+                name: "Comment",
+                table: "OkxDeposits");
+
+            migrationBuilder.DropColumn(
+                name: "TransactionFee",
+                table: "OkxDeposits");
+
+            migrationBuilder.DropColumn(
+                name: "WalletId",
+                table: "OkxDeposits");
+
+            migrationBuilder.DropColumn(
+                name: "From",
+                table: "MetamaskTransactions");
+
+            migrationBuilder.DropColumn(
+                name: "GasLimit",
+                table: "MetamaskTransactions");
+
+            migrationBuilder.DropColumn(
+                name: "GasPrice",
+                table: "MetamaskTransactions");
+
+            migrationBuilder.DropColumn(
+                name: "Hash",
+                table: "MetamaskTransactions");
+
+            migrationBuilder.DropColumn(
+                name: "To",
+                table: "MetamaskTransactions");
+
+            migrationBuilder.DropColumn(
+                name: "WalletId",
+                table: "MetamaskTransactions");
+
+            migrationBuilder.DropColumn(
+                name: "WalletId",
+                table: "MetamaskTrades");
+
+            migrationBuilder.DropColumn(
+                name: "WalletId",
+                table: "BitpandaTransactions");
+
+            migrationBuilder.DropColumn(
+                name: "WalletId",
+                table: "BitcoinDeTransactions");
+
+            migrationBuilder.DropColumn(
+                name: "WalletId",
+                table: "BinanceWithdrawals");
+
+            migrationBuilder.DropColumn(
+                name: "WalletId",
+                table: "BinanceTrades");
+
+            migrationBuilder.DropColumn(
+                name: "WalletId",
+                table: "BinanceDeposits");
+
+            migrationBuilder.RenameColumn(
+                name: "TXID",
+                table: "OkxDeposits",
+                newName: "Kommentar");
+
+            migrationBuilder.RenameColumn(
+                name: "ValueInUSD",
+                table: "MetamaskTransactions",
+                newName: "Typ");
+
+            migrationBuilder.RenameColumn(
+                name: "Value",
+                table: "MetamaskTransactions",
+                newName: "Network");
+
+            migrationBuilder.RenameColumn(
+                name: "Type",
+                table: "MetamaskTransactions",
+                newName: "Kommentar");
+
+            migrationBuilder.RenameColumn(
+                name: "TransactionFeeInUSD",
+                table: "MetamaskTransactions",
+                newName: "Coin");
+
+            migrationBuilder.RenameColumn(
+                name: "Date",
+                table: "MetamaskTransactions",
+                newName: "Datum");
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "TransactionFee",
+                table: "MetamaskTransactions",
+                type: "decimal(18,2)",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)");
+
+            migrationBuilder.AddColumn<decimal>(
+                name: "Amount",
+                table: "MetamaskTransactions",
+                type: "decimal(18,2)",
+                nullable: false,
+                defaultValue: 0m);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add DB entities for import records with wallet relations
- link wallet when storing raw import CSVs
- fetch wallets in import pages and use dropdown instead of text input
- include migration for new import entity tables with wallet relations

## Testing
- `dotnet build CryptoTracker.sln -v minimal`
- `dotnet test CryptoTracker.sln -v minimal`
