### PR TITLE
Convert to Blazor Server

### DIFF
--- a/src/CryptoTracker.Client/Pages/Bilanzen.razor
+++ b/src/CryptoTracker.Client/Pages/Bilanzen.razor
@@ -1,5 +1,4 @@
 @page "/bilanzen"
-@rendermode InteractiveAuto
 @using CryptoTracker.Shared
 @inject HttpClient HttpClient
 

--- a/src/CryptoTracker.Client/Pages/Import.razor
+++ b/src/CryptoTracker.Client/Pages/Import.razor
@@ -1,6 +1,5 @@
 ﻿@page "/import"
 @using CryptoTracker.Shared
-@rendermode InteractiveAuto
 @inject HttpClient HttpClient
 
 <PageTitle>Import</PageTitle>

--- a/src/CryptoTracker.Client/Pages/ImportPages/BinanceDepositPage.razor
+++ b/src/CryptoTracker.Client/Pages/ImportPages/BinanceDepositPage.razor
@@ -1,5 +1,4 @@
 @page "/import/binance-deposit"
 @using CryptoTracker.Shared
-@rendermode InteractiveAuto
 
 <ImportPageBase Title="Binance Deposit History" DocumentType="ImportDocumentType.BinanceDepositHistory" />

--- a/src/CryptoTracker.Client/Pages/ImportPages/BinanceTradePage.razor
+++ b/src/CryptoTracker.Client/Pages/ImportPages/BinanceTradePage.razor
@@ -1,5 +1,4 @@
 @page "/import/binance-trade"
 @using CryptoTracker.Shared
-@rendermode InteractiveAuto
 
 <ImportPageBase Title="Binance Trading History" DocumentType="ImportDocumentType.BinanceTradingHistory" />

--- a/src/CryptoTracker.Client/Pages/ImportPages/BinanceWithdrawalPage.razor
+++ b/src/CryptoTracker.Client/Pages/ImportPages/BinanceWithdrawalPage.razor
@@ -1,5 +1,4 @@
 @page "/import/binance-withdrawal"
 @using CryptoTracker.Shared
-@rendermode InteractiveAuto
 
 <ImportPageBase Title="Binance Withdrawal History" DocumentType="ImportDocumentType.BinanceWithdrawalHistory" />

--- a/src/CryptoTracker.Client/Pages/ImportPages/BitcoinDeTransactionsPage.razor
+++ b/src/CryptoTracker.Client/Pages/ImportPages/BitcoinDeTransactionsPage.razor
@@ -1,5 +1,4 @@
 @page "/import/bitcoinde-transactions"
 @using CryptoTracker.Shared
-@rendermode InteractiveAuto
 
 <ImportPageBase Title="Bitcoin.de Transactions" DocumentType="ImportDocumentType.BitcoinDeTransactions" />

--- a/src/CryptoTracker.Client/Pages/ImportPages/BitpandaTransactionsPage.razor
+++ b/src/CryptoTracker.Client/Pages/ImportPages/BitpandaTransactionsPage.razor
@@ -1,5 +1,4 @@
 @page "/import/bitpanda-transactions"
 @using CryptoTracker.Shared
-@rendermode InteractiveAuto
 
 <ImportPageBase Title="Bitpanda Transactions" DocumentType="ImportDocumentType.BitpandaTransaction" />

--- a/src/CryptoTracker.Client/Pages/ImportPages/MetamaskTradesPage.razor
+++ b/src/CryptoTracker.Client/Pages/ImportPages/MetamaskTradesPage.razor
@@ -1,5 +1,4 @@
 @page "/import/metamask-trades"
 @using CryptoTracker.Shared
-@rendermode InteractiveAuto
 
 <ImportPageBase Title="Metamask Trading History" DocumentType="ImportDocumentType.MetamaskTradingHistory" />

--- a/src/CryptoTracker.Client/Pages/ImportPages/MetamaskTransactionsPage.razor
+++ b/src/CryptoTracker.Client/Pages/ImportPages/MetamaskTransactionsPage.razor
@@ -1,5 +1,4 @@
 @page "/import/metamask-transactions"
 @using CryptoTracker.Shared
-@rendermode InteractiveAuto
 
 <ImportPageBase Title="Metamask Transactions" DocumentType="ImportDocumentType.MetamaskTransactions" />

--- a/src/CryptoTracker.Client/Pages/ImportPages/OkxDepositPage.razor
+++ b/src/CryptoTracker.Client/Pages/ImportPages/OkxDepositPage.razor
@@ -1,5 +1,4 @@
 @page "/import/okx-deposit"
 @using CryptoTracker.Shared
-@rendermode InteractiveAuto
 
 <ImportPageBase Title="Okx Deposit History" DocumentType="ImportDocumentType.OkxDepositHistory" />

--- a/src/CryptoTracker.Client/Pages/ImportPages/OkxTradePage.razor
+++ b/src/CryptoTracker.Client/Pages/ImportPages/OkxTradePage.razor
@@ -1,5 +1,4 @@
 @page "/import/okx-trade"
 @using CryptoTracker.Shared
-@rendermode InteractiveAuto
 
 <ImportPageBase Title="Okx Trading History" DocumentType="ImportDocumentType.OkxTradingHistory" />

--- a/src/CryptoTracker.Client/Pages/Overview.razor
+++ b/src/CryptoTracker.Client/Pages/Overview.razor
@@ -1,6 +1,5 @@
 ﻿@page "/"
 @using CryptoTracker.Shared
-@rendermode InteractiveAuto
 @inject HttpClient HttpClient
 
 <PageTitle>Überblick</PageTitle>

--- a/src/CryptoTracker.Client/Pages/Wallets.razor
+++ b/src/CryptoTracker.Client/Pages/Wallets.razor
@@ -1,5 +1,4 @@
 @page "/wallets"
-@rendermode InteractiveAuto
 @using CryptoTracker.Shared
 @inject HttpClient HttpClient
 

--- a/src/CryptoTracker.Client/_Imports.razor
+++ b/src/CryptoTracker.Client/_Imports.razor
@@ -3,7 +3,6 @@
 @using Microsoft.AspNetCore.Components.Forms
 @using Microsoft.AspNetCore.Components.Routing
 @using Microsoft.AspNetCore.Components.Web
-@using static Microsoft.AspNetCore.Components.Web.RenderMode
 @using Microsoft.AspNetCore.Components.Web.Virtualization
 @using Microsoft.JSInterop
 @using CryptoTracker.Client

--- a/src/CryptoTracker/Components/_Imports.razor
+++ b/src/CryptoTracker/Components/_Imports.razor
@@ -3,7 +3,6 @@
 @using Microsoft.AspNetCore.Components.Forms
 @using Microsoft.AspNetCore.Components.Routing
 @using Microsoft.AspNetCore.Components.Web
-@using static Microsoft.AspNetCore.Components.Web.RenderMode
 @using Microsoft.AspNetCore.Components.Web.Virtualization
 @using Microsoft.JSInterop
 @using CryptoTracker

--- a/src/CryptoTracker/Startup.cs
+++ b/src/CryptoTracker/Startup.cs
@@ -34,8 +34,8 @@ namespace CryptoTracker
                 options.UseSqlServer(Configuration.GetConnectionString("DefaultConnection")));
 
             services.AddRazorComponents()
-                .AddInteractiveServerComponents()
-                .AddInteractiveWebAssemblyComponents();
+                .AddInteractiveServerComponents();
+                //.AddInteractiveWebAssemblyComponents();
 
             services.AddBlazorise(options => { options.Immediate = true; })
                 .AddBootstrap5Providers()
@@ -74,7 +74,8 @@ namespace CryptoTracker
                 app.UseHsts();
             }
 
-            app.UseBlazorFrameworkFiles();
+
+            //app.UseBlazorFrameworkFiles();
 
             app.UseHttpsRedirection();
             app.UseStaticFiles();
@@ -86,7 +87,7 @@ namespace CryptoTracker
             {
                 endpoints.MapRazorComponents<App>()
                     .AddInteractiveServerRenderMode()
-                    .AddInteractiveWebAssemblyRenderMode()
+                    //.AddInteractiveWebAssemblyRenderMode()
                     .AddAdditionalAssemblies(typeof(Overview).Assembly);
                 endpoints.MapControllers();
                 endpoints.MapDefaultControllerRoute();


### PR DESCRIPTION
## Summary
- swap Blazor project to use server render mode only
- remove @rendermode directives
- update imports to drop RenderMode
- comment out WebAssembly setup instead of removing

## Testing
- `dotnet test CryptoTracker.sln`