### PR TITLE
Switch to CoinMarketCap provider

### DIFF
--- a/infra/appservice/appservice.bicep
+++ b/infra/appservice/appservice.bicep
@@ -47,8 +47,7 @@ resource appService 'Microsoft.Web/sites@2022-03-01' = {
           }
           {
             name: 'COINMARKETCAP_API_KEY'
-            // @Microsoft.KeyVault reference to secret Uri
-            value: coinmarketcapApiKeyKVUri
+            value: '@Microsoft.KeyVault(SecretUri=${coinmarketcapApiKeyKVUri})'
           }
         ]
         connectionStrings: [

--- a/infra/appservice/appservice.bicep
+++ b/infra/appservice/appservice.bicep
@@ -14,6 +14,9 @@ param applicationInsightsName string
 @secure()
 param azureDbConnectionString string
 
+@description('Key Vault reference to the CoinMarketCap API key')
+param coinmarketcapApiKeyKVUri string
+
 @description('Tenant id used for restricting authentication to the current tenant')
 param tenantId string = tenant().tenantId
 
@@ -41,6 +44,11 @@ resource appService 'Microsoft.Web/sites@2022-03-01' = {
           {
             name: 'APPLICATIONINSIGHTS_CONNECTION_STRING'
             value: applicationInsights.properties.ConnectionString
+          }
+          {
+            name: 'COINMARKETCAP_API_KEY'
+            // @Microsoft.KeyVault reference to secret Uri
+            value: coinmarketcapApiKeyKVUri
           }
         ]
         connectionStrings: [

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -15,6 +15,9 @@ param logAnalyticsWorkspaceName string = 'log-${environmentName}'
 @secure()
 param azureDbConnectionString string
 
+@description('Key Vault reference to the CoinMarketCap API key')
+param coinmarketcapApiKeyKVUri string
+
 var tags = { 'azd-env-name': environmentName }
 
 resource appServicePlan 'Microsoft.Web/serverfarms@2022-03-01' existing = {
@@ -41,6 +44,7 @@ module appService 'appservice/appservice.bicep' = {
     appServicePlanId: appServicePlan.id
     applicationInsightsName: applicationInsights.outputs.name
     azureDbConnectionString: azureDbConnectionString
+    coinmarketcapApiKeyKVUri: coinmarketcapApiKeyKVUri
     tenantId: tenant().tenantId
   }
 }

--- a/infra/main.parameters.json
+++ b/infra/main.parameters.json
@@ -13,6 +13,9 @@
     },
     "appServicePlanName": {
       "value": "ASP-P0V3-default"
+    },
+    "coinmarketcapApiKeyKVUri": {
+      "value": "@Microsoft.KeyVault(SecretUri=https://humer.vault.azure.net/secrets/CoinmarketcapApiKey/efb646621bb947109da10d8ffe45e5c1)"
     }
   }
 }

--- a/infra/main.parameters.json
+++ b/infra/main.parameters.json
@@ -15,7 +15,7 @@
       "value": "ASP-P0V3-default"
     },
     "coinmarketcapApiKeyKVUri": {
-      "value": "@Microsoft.KeyVault(SecretUri=https://humer.vault.azure.net/secrets/CoinmarketcapApiKey/efb646621bb947109da10d8ffe45e5c1)"
+      "value": "https://humer.vault.azure.net/secrets/CoinmarketcapApiKey/efb646621bb947109da10d8ffe45e5c1"
     }
   }
 }

--- a/src/CryptoTracker/CryptoTracker.csproj
+++ b/src/CryptoTracker/CryptoTracker.csproj
@@ -16,7 +16,6 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Finance.NET" Version="1.0.7" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.23.0" />
     <PackageReference Include="Blazorise" Version="1.7.6" />
     <PackageReference Include="Blazorise.Bootstrap5" Version="1.7.6" />

--- a/src/CryptoTracker/Services/BalanceService.cs
+++ b/src/CryptoTracker/Services/BalanceService.cs
@@ -43,17 +43,12 @@ public class BalanceService
             .ToList();
 
         var result = new List<PlatformBalanceDTO>();
-        var rateCache = new Dictionary<string, decimal>();
         foreach (var walletGroup in all.GroupBy(x => x.Wallet))
         {
             var assets = new List<AssetBalanceDTO>();
             foreach (var asset in walletGroup)
             {
-                if (!rateCache.TryGetValue(asset.Symbol, out var rate))
-                {
-                    rate = await _valueProvider.GetCurrentEuroValueAsync(asset.Symbol);
-                    rateCache[asset.Symbol] = rate;
-                }
+                var rate = await _valueProvider.GetCurrentEuroValueAsync(asset.Symbol);
 
                 assets.Add(new AssetBalanceDTO(asset.Symbol, asset.Amount, asset.Amount * rate
                 ));

--- a/src/CryptoTracker/Services/FinanceValueProvider.cs
+++ b/src/CryptoTracker/Services/FinanceValueProvider.cs
@@ -1,27 +1,51 @@
-using Finance.Net.Interfaces;
-using Finance.Net.Models.Yahoo;
-using Finance.Net.Exceptions;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+using NoobsMuc.Coinmarketcap.Client;
 
 namespace CryptoTracker.Services;
 
 public class FinanceValueProvider : IFinanceValueProvider
 {
-    private readonly IYahooFinanceService _financeService;
+    private readonly ICoinmarketcapClient _client;
+    private readonly IMemoryCache _cache;
+    private readonly ILogger<FinanceValueProvider> _logger;
 
-    public FinanceValueProvider(IYahooFinanceService financeService)
+    public FinanceValueProvider(ICoinmarketcapClient client, IMemoryCache cache, ILogger<FinanceValueProvider> logger)
     {
-        _financeService = financeService;
+        _client = client;
+        _cache = cache;
+        _logger = logger;
     }
 
     public async Task<decimal> GetCurrentEuroValueAsync(string symbol)
     {
+        var cacheKey = $"eur-price-{symbol}";
+        if (_cache.TryGetValue(cacheKey, out decimal cached))
+        {
+            return cached;
+        }
+
         try
         {
-            Quote quote = await _financeService.GetQuoteAsync($"{symbol}-EUR");
-            return Convert.ToDecimal(quote.RegularMarketPrice ?? 0d);
+            dynamic dynamicClient = _client;
+            var response = await dynamicClient.GetCurrencyBySymbol(symbol);
+            string json = JsonConvert.SerializeObject(response);
+            using var doc = System.Text.Json.JsonDocument.Parse(json);
+            var price = doc.RootElement
+                .GetProperty("data")
+                .EnumerateObject().First().Value
+                .GetProperty("quote")
+                .GetProperty("EUR")
+                .GetProperty("price")
+                .GetDecimal();
+
+            _cache.Set(cacheKey, price, TimeSpan.FromMinutes(15));
+            return price;
         }
-        catch (FinanceNetException)
+        catch (Exception ex)
         {
+            _logger.LogWarning(ex, "Could not retrieve value for {Symbol}", symbol);
             return 0m;
         }
     }

--- a/src/CryptoTracker/Startup.cs
+++ b/src/CryptoTracker/Startup.cs
@@ -3,8 +3,7 @@ using CryptoTracker.Components;
 using CryptoTracker.Client.Pages;
 using Microsoft.AspNetCore.Components;
 using CryptoTracker.Services;
-using Finance.Net;
-using Finance.Net.Extensions;
+using NoobsMuc.Coinmarketcap.Client;
 using Blazorise;
 using Blazorise.Bootstrap5;
 using Blazorise.Icons.FontAwesome;
@@ -41,10 +40,9 @@ namespace CryptoTracker
                 .AddBootstrap5Providers()
                 .AddFontAwesomeIcons();
 
-            services.AddFinanceNet(new FinanceNetConfiguration()
-            {
-                HttpRetryCount = 3
-            });
+            services.AddMemoryCache();
+            services.AddSingleton<ICoinmarketcapClient>(sp =>
+                new CoinmarketcapClient(Configuration["COINMARKETCAP_API_KEY"]!));
 
             services.AddScoped<HttpClient>(sp =>
             {


### PR DESCRIPTION
## Summary
- replace Yahoo-based value provider with CoinMarketCap client
- cache price lookups for 15 minutes
- inject `ICoinmarketcapClient` using API key from configuration
- pass CoinMarketCap API key via bicep and parameter file
- remove Finance.NET package
- address review comments (rename parameter, remove local rate cache)

## Testing
- `dotnet restore`
- `dotnet build --no-restore`
- `dotnet test --no-build --verbosity minimal`
