### PR TITLE
Replace DataGrid with Radzen version

### DIFF
--- a/src/CryptoTracker.Client/CryptoTracker.Client.csproj
+++ b/src/CryptoTracker.Client/CryptoTracker.Client.csproj
@@ -15,6 +15,6 @@
     <PackageReference Include="Blazorise" Version="1.7.6" />
     <PackageReference Include="Blazorise.Bootstrap5" Version="1.7.6" />
     <PackageReference Include="Blazorise.Icons.FontAwesome" Version="1.7.6" />
-    <PackageReference Include="Blazorise.DataGrid" Version="1.7.6" />
+    <PackageReference Include="Radzen.Blazor" Version="7.0.6" />
   </ItemGroup>
 </Project>

--- a/src/CryptoTracker.Client/Pages/Bilanzen.razor
+++ b/src/CryptoTracker.Client/Pages/Bilanzen.razor
@@ -17,13 +17,13 @@ else if (Balances != null)
     foreach (var balance in Balances)
     {
         <h5 class="mt-3">@balance.Platform</h5>
-        <DataGrid TItem="AssetBalanceDTO" Data="balance.Assets" Sortable="true" Filterable="true" Resizable="true" ShowPager="false">
-            <DataGridColumns>
-                <DataGridColumn TItem="AssetBalanceDTO" Field="@nameof(AssetBalanceDTO.Symbol)" Caption="Symbol" />
-                <DataGridColumn TItem="AssetBalanceDTO" Field="@nameof(AssetBalanceDTO.Amount)" Caption="Menge" />
-                <DataGridColumn TItem="AssetBalanceDTO" Field="@nameof(AssetBalanceDTO.EuroValue)" Caption="Wert in EUR" />
-            </DataGridColumns>
-        </DataGrid>
+        <RadzenDataGrid TItem="AssetBalanceDTO" Data="balance.Assets" AllowSorting="true" AllowFiltering="true" AllowColumnResize="true" AllowPaging="false">
+            <Columns>
+                <RadzenDataGridColumn TItem="AssetBalanceDTO" Property="@nameof(AssetBalanceDTO.Symbol)" Title="Symbol" />
+                <RadzenDataGridColumn TItem="AssetBalanceDTO" Property="@nameof(AssetBalanceDTO.Amount)" Title="Menge" />
+                <RadzenDataGridColumn TItem="AssetBalanceDTO" Property="@nameof(AssetBalanceDTO.EuroValue)" Title="Wert in EUR" />
+            </Columns>
+        </RadzenDataGrid>
     }
 }
 

--- a/src/CryptoTracker.Client/Pages/ImportPages/ImportPageBase.razor
+++ b/src/CryptoTracker.Client/Pages/ImportPages/ImportPageBase.razor
@@ -26,14 +26,14 @@ else if (Entries.Count > 0)
         .Where(p => p.Name != "Id")
         .Select(p => p.Name)
         .ToList();
-    <DataGrid TItem="TEntry" Data="Entries" Filterable="true" FilterMode="DataGridFilterMode.Menu" ShowPager="false">
-        <DataGridColumns>
+    <RadzenDataGrid TItem="TEntry" Data="Entries" AllowFiltering="true" AllowPaging="false">
+        <Columns>
             @foreach (var h in headers)
             {
-                <DataGridColumn TItem="TEntry" Field="@h" Caption="@h" />
+                <RadzenDataGridColumn TItem="TEntry" Property="@h" Title="@h" />
             }
-        </DataGridColumns>
-    </DataGrid>
+        </Columns>
+    </RadzenDataGrid>
 }
 
 @if (ErrorMessage != null)

--- a/src/CryptoTracker.Client/Pages/Overview.razor
+++ b/src/CryptoTracker.Client/Pages/Overview.razor
@@ -44,16 +44,16 @@ else
     </div>
 
     <div class="mt-3">
-        <DataGrid TItem="FlowDTO" Data="Flows" Sortable="true" Filterable="true" Resizable="true" ShowPager="false">
-            <DataGridColumns>
-                <DataGridColumn TItem="FlowDTO" Field="@nameof(FlowDTO.DateTime)" Caption="DateTime" />
-                <DataGridColumn TItem="FlowDTO" Field="@nameof(FlowDTO.FlowType)" Caption="FlowType" />
-                <DataGridColumn TItem="FlowDTO" Field="@nameof(FlowDTO.FlowDirection)" Caption="FlowDirection" />
-                <DataGridColumn TItem="FlowDTO" Field="@nameof(FlowDTO.SourceWallet)" Caption="SourceWallet" />
-                <DataGridColumn TItem="FlowDTO" Field="@nameof(FlowDTO.TargetWallet)" Caption="TargetWallet" />
-                <DataGridColumn TItem="FlowDTO" Field="@nameof(FlowDTO.FlowAmount)" Caption="FlowAmount" />
-            </DataGridColumns>
-        </DataGrid>
+        <RadzenDataGrid TItem="FlowDTO" Data="Flows" AllowSorting="true" AllowFiltering="true" AllowColumnResize="true" AllowPaging="false">
+            <Columns>
+                <RadzenDataGridColumn TItem="FlowDTO" Property="@nameof(FlowDTO.DateTime)" Title="DateTime" />
+                <RadzenDataGridColumn TItem="FlowDTO" Property="@nameof(FlowDTO.FlowType)" Title="FlowType" />
+                <RadzenDataGridColumn TItem="FlowDTO" Property="@nameof(FlowDTO.FlowDirection)" Title="FlowDirection" />
+                <RadzenDataGridColumn TItem="FlowDTO" Property="@nameof(FlowDTO.SourceWallet)" Title="SourceWallet" />
+                <RadzenDataGridColumn TItem="FlowDTO" Property="@nameof(FlowDTO.TargetWallet)" Title="TargetWallet" />
+                <RadzenDataGridColumn TItem="FlowDTO" Property="@nameof(FlowDTO.FlowAmount)" Title="FlowAmount" />
+            </Columns>
+        </RadzenDataGrid>
     </div>
 
     <div class="mt-3">

--- a/src/CryptoTracker.Client/Pages/Wallets.razor
+++ b/src/CryptoTracker.Client/Pages/Wallets.razor
@@ -12,17 +12,17 @@
     <button class="btn btn-secondary mt-2" @onclick="NewWallet">Neu</button>
 </div>
 
-<DataGrid TItem="WalletInfoDTO" Data="WalletsList" Sortable="true" Filterable="true" Resizable="true" ShowPager="false">
-    <DataGridColumns>
-        <DataGridColumn TItem="WalletInfoDTO" Field="@nameof(WalletInfoDTO.Name)" Caption="Name" />
-        <DataGridColumn TItem="WalletInfoDTO">
-            <DisplayTemplate Context="w">
+<RadzenDataGrid TItem="WalletInfoDTO" Data="WalletsList" AllowSorting="true" AllowFiltering="true" AllowColumnResize="true" AllowPaging="false">
+    <Columns>
+        <RadzenDataGridColumn TItem="WalletInfoDTO" Property="@nameof(WalletInfoDTO.Name)" Title="Name" />
+        <RadzenDataGridColumn TItem="WalletInfoDTO">
+            <Template Context="w">
                 <button class="btn btn-sm btn-secondary me-1" @onclick="(() => Edit(w))">Ändern</button>
                 <button class="btn btn-sm btn-danger" @onclick="(() => Delete(w.Id))">Löschen</button>
-            </DisplayTemplate>
-        </DataGridColumn>
-    </DataGridColumns>
-</DataGrid>
+            </Template>
+        </RadzenDataGridColumn>
+    </Columns>
+</RadzenDataGrid>
 
 @if (ErrorMessage != null)
 {

--- a/src/CryptoTracker.Client/_Imports.razor
+++ b/src/CryptoTracker.Client/_Imports.razor
@@ -8,4 +8,4 @@
 @using CryptoTracker.Client
 @using Microsoft.Extensions.Localization
 @using Blazorise
-@using Blazorise.DataGrid
+@using Radzen

--- a/src/CryptoTracker/Components/_Imports.razor
+++ b/src/CryptoTracker/Components/_Imports.razor
@@ -10,4 +10,4 @@
 @using CryptoTracker.Components
 @using Microsoft.Extensions.Localization
 @using Blazorise
-@using Blazorise.DataGrid
+@using Radzen

--- a/src/CryptoTracker/CryptoTracker.csproj
+++ b/src/CryptoTracker/CryptoTracker.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="Blazorise" Version="1.7.6" />
     <PackageReference Include="Blazorise.Bootstrap5" Version="1.7.6" />
     <PackageReference Include="Blazorise.Icons.FontAwesome" Version="1.7.6" />
-    <PackageReference Include="Blazorise.DataGrid" Version="1.7.6" />
+    <PackageReference Include="Radzen.Blazor" Version="7.0.6" />
     <PackageReference Include="NoobsMuc.Coinmarketcap.Client" Version="3.1.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.5">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
## Summary
- use `Radzen.Blazor` DataGrid instead of `Blazorise.DataGrid`
- update imports to reference Radzen
- convert DataGrid markup on all pages

## Testing
- `dotnet test` *(fails: Failed to retrieve information about 'Radzen.Blazor' from remote source)*