### PR TITLE
Fix Radzen namespace for DataGrid usage

### DIFF
--- a/src/CryptoTracker.Client/_Imports.razor
+++ b/src/CryptoTracker.Client/_Imports.razor
@@ -8,4 +8,5 @@
 @using CryptoTracker.Client
 @using Microsoft.Extensions.Localization
 @using Blazorise
+@using Radzen.Blazor
 @using Radzen

--- a/src/CryptoTracker/Components/_Imports.razor
+++ b/src/CryptoTracker/Components/_Imports.razor
@@ -10,4 +10,5 @@
 @using CryptoTracker.Components
 @using Microsoft.Extensions.Localization
 @using Blazorise
+@using Radzen.Blazor
 @using Radzen


### PR DESCRIPTION
## Summary
- add `Radzen.Blazor` to component imports so RadzenDataGrid components are recognized

## Testing
- `dotnet build`
- `dotnet test`
