### PR TITLE
Fix Radzen setup and duplicate trade key

### DIFF
--- a/src/CryptoTracker.Client/Shared/Imports/BinanceTradeDTO.cs
+++ b/src/CryptoTracker.Client/Shared/Imports/BinanceTradeDTO.cs
@@ -2,6 +2,7 @@ namespace CryptoTracker.Shared;
 
 public record BinanceTradeDTO
 {
+    public int Id { get; set; }
     public DateTimeOffset Date { get; set; }
     public string Pair { get; set; } = string.Empty;
     public string Side { get; set; } = string.Empty;

--- a/src/CryptoTracker.Client/_Imports.razor
+++ b/src/CryptoTracker.Client/_Imports.razor
@@ -8,5 +8,5 @@
 @using CryptoTracker.Client
 @using Microsoft.Extensions.Localization
 @using Blazorise
-@using Radzen.Blazor
 @using Radzen
+@using Radzen.Blazor

--- a/src/CryptoTracker/Components/App.razor
+++ b/src/CryptoTracker/Components/App.razor
@@ -10,16 +10,19 @@
 
     <link href="_content/Blazorise/blazorise.css?v=1.7.6.0" rel="stylesheet" />
     <link href="_content/Blazorise.Bootstrap5/blazorise.bootstrap5.css?v=1.7.6.0" rel="stylesheet" />
+    <link href="_content/Radzen.Blazor/css/material3-base.css" rel="stylesheet" />
     <link rel="stylesheet" href="app.css" />
     <link rel="stylesheet" href="CryptoTracker.styles.css" />
     <link rel="icon" type="image/png" href="favicon.png" />
     <HeadOutlet />
+    <RadzenTheme Theme="material" @rendermode="RenderMode.InteractiveAuto" />
 </head>
 
 <body>
     <Routes />
     <script src="_content/Blazorise/blazorise.js"></script>
     <script src="_framework/blazor.web.js"></script>
+    <script src="_content/Radzen.Blazor/Radzen.Blazor.js?v=@(typeof(Radzen.Colors).Assembly.GetName().Version)"></script>
 </body>
 
 </html>

--- a/src/CryptoTracker/Components/_Imports.razor
+++ b/src/CryptoTracker/Components/_Imports.razor
@@ -10,5 +10,5 @@
 @using CryptoTracker.Components
 @using Microsoft.Extensions.Localization
 @using Blazorise
-@using Radzen.Blazor
 @using Radzen
+@using Radzen.Blazor


### PR DESCRIPTION
## Summary
- add Radzen Blazor css and js to the host page
- include unique `Id` property in `BinanceTradeDTO`
- ensure Radzen namespaces are imported
- set up `RadzenTheme` with render mode

## Testing
- `dotnet test`