### PR TITLE
Adjust wallets endpoint and DTO

### DIFF
--- a/src/CryptoTracker.Client/Pages/Overview.razor.cs
+++ b/src/CryptoTracker.Client/Pages/Overview.razor.cs
@@ -10,10 +10,10 @@ namespace CryptoTracker.Client.Pages
         
         private string? ErrorMessage { get; set; }
 
-        private IList<WalletDTO>? Wallets { get; set; }
+        private IList<WalletWithSymbolsDTO>? Wallets { get; set; }
         private IList<string>? Symbols { get; set; }
 
-        private WalletDTO? SelectedWallet { get; set; }
+        private WalletWithSymbolsDTO? SelectedWallet { get; set; }
         private string? SelectedWalletName { get; set; }
         private string? SelectedSymbol { get; set; }
 
@@ -24,7 +24,7 @@ namespace CryptoTracker.Client.Pages
         {
             await base.OnInitializedAsync();
 
-            Wallets = await WalletApi.GetWalletsAsync();
+            Wallets = await WalletApi.GetWalletsWithSymbolsAsync();
 
             IsLoading = false;
         }

--- a/src/CryptoTracker.Client/RestClients/WalletRestClient.cs
+++ b/src/CryptoTracker.Client/RestClients/WalletRestClient.cs
@@ -15,6 +15,9 @@ public class WalletRestClient : IWalletApi
     public async Task<IList<WalletDTO>> GetWalletsAsync()
         => await _http.GetFromJsonAsync<IList<WalletDTO>>("api/Wallet/GetWallets") ?? new List<WalletDTO>();
 
+    public async Task<IList<WalletWithSymbolsDTO>> GetWalletsWithSymbolsAsync()
+        => await _http.GetFromJsonAsync<IList<WalletWithSymbolsDTO>>("api/Wallet/GetWalletsWithSymbols") ?? new List<WalletWithSymbolsDTO>();
+
     public async Task<IList<WalletInfoDTO>> GetWalletInfosAsync()
         => await _http.GetFromJsonAsync<IList<WalletInfoDTO>>("api/Wallet/GetWalletInfos") ?? new List<WalletInfoDTO>();
 

--- a/src/CryptoTracker.Client/Shared/Api/IWalletApi.cs
+++ b/src/CryptoTracker.Client/Shared/Api/IWalletApi.cs
@@ -3,6 +3,7 @@ namespace CryptoTracker.Shared;
 public interface IWalletApi
 {
     Task<IList<WalletDTO>> GetWalletsAsync();
+    Task<IList<WalletWithSymbolsDTO>> GetWalletsWithSymbolsAsync();
     Task<IList<WalletInfoDTO>> GetWalletInfosAsync();
     Task<WalletInfoDTO> SaveWalletAsync(WalletInfoDTO wallet);
     Task DeleteWalletAsync(int id);

--- a/src/CryptoTracker.Client/Shared/WalletDTO.cs
+++ b/src/CryptoTracker.Client/Shared/WalletDTO.cs
@@ -1,3 +1,3 @@
-﻿namespace CryptoTracker.Shared;
+namespace CryptoTracker.Shared;
 
-public record WalletDTO(string Name, string[] Symbols);
+public record WalletDTO(string Name);

--- a/src/CryptoTracker.Client/Shared/WalletWithSymbolsDTO.cs
+++ b/src/CryptoTracker.Client/Shared/WalletWithSymbolsDTO.cs
@@ -1,0 +1,3 @@
+namespace CryptoTracker.Shared;
+
+public record WalletWithSymbolsDTO(string Name, string[] Symbols);

--- a/src/CryptoTracker/Controllers/WalletController.cs
+++ b/src/CryptoTracker/Controllers/WalletController.cs
@@ -19,8 +19,17 @@ public class WalletController : ControllerBase, IWalletApi
     [HttpGet("GetWallets")]
     public async Task<IActionResult> GetWallets()
     {
-        var wallets = await _walletService.GetWalletAndSymbols();
-        var walletDTOs = wallets.Select(w => new WalletDTO(w.wallet, w.symbols)).ToList();
+        var wallets = await _walletService.GetWallets();
+        var walletDTOs = wallets.Select(w => new WalletDTO(w.Name)).ToList();
+
+        return Ok(walletDTOs);
+    }
+
+    [HttpGet("GetWalletsWithSymbols")]
+    public async Task<IActionResult> GetWalletsWithSymbols()
+    {
+        var wallets = await _walletService.GetWalletsWithSymbols();
+        var walletDTOs = wallets.Select(w => new WalletWithSymbolsDTO(w.wallet.Name, w.symbols)).ToList();
 
         return Ok(walletDTOs);
     }
@@ -41,9 +50,12 @@ public class WalletController : ControllerBase, IWalletApi
     }
 
     async Task<IList<WalletDTO>> IWalletApi.GetWalletsAsync()
+        => (await _walletService.GetWallets()).Select(w => new WalletDTO(w.Name)).ToList();
+
+    async Task<IList<WalletWithSymbolsDTO>> IWalletApi.GetWalletsWithSymbolsAsync()
     {
-        var wallets = await _walletService.GetWalletAndSymbols();
-        return wallets.Select(w => new WalletDTO(w.wallet, w.symbols)).ToList();
+        var wallets = await _walletService.GetWalletsWithSymbols();
+        return wallets.Select(w => new WalletWithSymbolsDTO(w.wallet.Name, w.symbols)).ToList();
     }
 
     async Task<IList<WalletInfoDTO>> IWalletApi.GetWalletInfosAsync()


### PR DESCRIPTION
## Summary
- return only wallet data from `GetWallets`
- add `WalletWithSymbolsDTO` and new `GetWalletsWithSymbols` endpoint
- update wallet service and rest client
- adjust overview page to consume new API
- adapt `IWalletApi` interface

## Testing
- `dotnet test`