### PR TITLE
Enable wallet names in import DTOs

### DIFF
--- a/src/CryptoTracker.Client/Common/ImportEntryExtensions.cs
+++ b/src/CryptoTracker.Client/Common/ImportEntryExtensions.cs
@@ -1,0 +1,24 @@
+using System.Text.Json;
+using CryptoTracker.Shared;
+
+namespace CryptoTracker.Common;
+
+public static class ImportEntryExtensions
+{
+    public static TDto CloneToDTO<TDto>(this object entity)
+    {
+        var json = JsonSerializer.Serialize(entity);
+        var dto = JsonSerializer.Deserialize<TDto>(json)!;
+
+        var walletPropEntity = entity.GetType().GetProperty("Wallet");
+        var walletPropDto = typeof(TDto).GetProperty("Wallet");
+        if (walletPropEntity != null && walletPropDto != null)
+        {
+            var wallet = walletPropEntity.GetValue(entity);
+            var nameProp = wallet?.GetType().GetProperty("Name");
+            var walletName = nameProp?.GetValue(wallet)?.ToString() ?? string.Empty;
+            walletPropDto.SetValue(dto, walletName);
+        }
+        return dto;
+    }
+}

--- a/src/CryptoTracker.Client/Pages/ImportPages/ImportPageBase.razor
+++ b/src/CryptoTracker.Client/Pages/ImportPages/ImportPageBase.razor
@@ -102,6 +102,20 @@ else if (Entries.Count > 0)
             Entries = jsonEntries
                 .Select(e => JsonSerializer.Deserialize<TEntry>(e.GetRawText(), options)!)
                 .ToList();
+
+
+            var dateProp = typeof(TEntry).GetProperties()
+                .FirstOrDefault(p => p.PropertyType == typeof(DateTimeOffset) || p.PropertyType == typeof(DateTime));
+            if (dateProp != null)
+            {
+                Entries = Entries.OrderBy(e =>
+                {
+                    var val = dateProp.GetValue(e);
+                    if (val is DateTimeOffset dto) return dto;
+                    if (val is DateTime dt) return (DateTimeOffset)dt;
+                    return DateTimeOffset.MinValue;
+                }).ToList();
+            }
         }
         else
         {

--- a/src/CryptoTracker.Client/Pages/Overview.razor
+++ b/src/CryptoTracker.Client/Pages/Overview.razor
@@ -20,10 +20,6 @@ else
         <RadzenDropDown Style="width:100%" Data="@Wallets" TextProperty="Name" ValueProperty="Name" @bind-Value="SelectedWalletName" Change="@(args => OnSelectedWalletChanged(args?.ToString() ?? string.Empty))" Placeholder="Select Wallet" />
     </div>
 
-    <div class="mt-3" style="max-width:200px">
-        <label>Select Symbol:</label>
-        <RadzenDropDown Style="width:100%" Data="@Symbols" @bind-Value="SelectedSymbol" Change="@(args => OnSelectedSymbolChanged(args))" Placeholder="Select Symbol" />
-    </div>
 
     <div class="mt-3">
         <RadzenDataGrid TItem="FlowDTO" Data="Flows" AllowSorting="true" AllowFiltering="true" AllowColumnResize="true" AllowPaging="false">

--- a/src/CryptoTracker.Client/Pages/Overview.razor.cs
+++ b/src/CryptoTracker.Client/Pages/Overview.razor.cs
@@ -11,11 +11,9 @@ namespace CryptoTracker.Client.Pages
         private string? ErrorMessage { get; set; }
 
         private IList<WalletWithSymbolsDTO>? Wallets { get; set; }
-        private IList<string>? Symbols { get; set; }
 
         private WalletWithSymbolsDTO? SelectedWallet { get; set; }
         private string? SelectedWalletName { get; set; }
-        private string? SelectedSymbol { get; set; }
 
         private IList<FlowDTO> Flows { get; set; } = new List<FlowDTO>();
         private decimal Balance { get; set; }
@@ -33,24 +31,15 @@ namespace CryptoTracker.Client.Pages
         {
             SelectedWalletName = walletName;
             SelectedWallet = Wallets?.FirstOrDefault(w => w.Name == walletName);
-            Symbols = SelectedWallet?.Symbols.ToList();
 
-            if (SelectedWallet != null && SelectedSymbol != null)
-                await LoadData();
-        }
-
-        private async Task OnSelectedSymbolChanged(object value)
-        {
-            SelectedSymbol = value?.ToString();
-
-            if (SelectedWallet != null && SelectedSymbol != null)
+            if (SelectedWallet != null)
                 await LoadData();
         }
 
         private async Task LoadData()
         {
             IsLoading = true;
-            var response = await FlowApi.GetFlowsAsync(SelectedWallet?.Name ?? string.Empty, SelectedSymbol ?? string.Empty);
+            var response = await FlowApi.GetFlowsAsync(SelectedWallet?.Name ?? string.Empty);
             if (response != null)
             {
                 Flows = response.Flows ?? new List<FlowDTO>();

--- a/src/CryptoTracker.Client/RestClients/FlowRestClient.cs
+++ b/src/CryptoTracker.Client/RestClients/FlowRestClient.cs
@@ -13,6 +13,6 @@ public class FlowRestClient : IFlowApi
         _http = http;
     }
 
-    public Task<FlowsResponse?> GetFlowsAsync(string walletName, string symbolName)
-        => _http.GetFromJsonAsync<FlowsResponse>($"api/Flow/GetFlows?walletName={walletName}&symbolName={symbolName}");
+    public Task<FlowsResponse?> GetFlowsAsync(string walletName)
+        => _http.GetFromJsonAsync<FlowsResponse>($"api/Flow/GetFlows?walletName={walletName}");
 }

--- a/src/CryptoTracker.Client/Shared/Api/IFlowApi.cs
+++ b/src/CryptoTracker.Client/Shared/Api/IFlowApi.cs
@@ -4,5 +4,5 @@ namespace CryptoTracker.Shared;
 
 public interface IFlowApi
 {
-    Task<FlowsResponse?> GetFlowsAsync(string walletName, string symbolName);
+    Task<FlowsResponse?> GetFlowsAsync(string walletName);
 }

--- a/src/CryptoTracker.Client/Shared/Imports/BinanceDepositDTO.cs
+++ b/src/CryptoTracker.Client/Shared/Imports/BinanceDepositDTO.cs
@@ -1,7 +1,12 @@
+using System.Text.Json.Serialization;
+
 namespace CryptoTracker.Shared;
 
 public record BinanceDepositDTO
 {
+    public int WalletId { get; set; }
+    public string Wallet { get; set; } = string.Empty;
+
     public DateTimeOffset Date { get; set; }
     public string Coin { get; set; } = string.Empty;
     public string Network { get; set; } = string.Empty;

--- a/src/CryptoTracker.Client/Shared/Imports/BinanceTradeDTO.cs
+++ b/src/CryptoTracker.Client/Shared/Imports/BinanceTradeDTO.cs
@@ -1,8 +1,13 @@
+using System.Text.Json.Serialization;
+
 namespace CryptoTracker.Shared;
 
 public record BinanceTradeDTO
 {
     public int Id { get; set; }
+    public int WalletId { get; set; }
+    public string Wallet { get; set; } = string.Empty;
+
     public DateTimeOffset Date { get; set; }
     public string Pair { get; set; } = string.Empty;
     public string Side { get; set; } = string.Empty;

--- a/src/CryptoTracker.Client/Shared/Imports/BinanceWithdrawalDTO.cs
+++ b/src/CryptoTracker.Client/Shared/Imports/BinanceWithdrawalDTO.cs
@@ -1,7 +1,12 @@
+using System.Text.Json.Serialization;
+
 namespace CryptoTracker.Shared;
 
 public record BinanceWithdrawalDTO
 {
+    public int WalletId { get; set; }
+    public string Wallet { get; set; } = string.Empty;
+
     public DateTimeOffset Date { get; set; }
     public string Coin { get; set; } = string.Empty;
     public string Network { get; set; } = string.Empty;

--- a/src/CryptoTracker.Client/Shared/Imports/BitcoinDeTransactionDTO.cs
+++ b/src/CryptoTracker.Client/Shared/Imports/BitcoinDeTransactionDTO.cs
@@ -1,7 +1,12 @@
+using System.Text.Json.Serialization;
+
 namespace CryptoTracker.Shared;
 
 public record BitcoinDeTransactionDTO
 {
+    public int WalletId { get; set; }
+    public string Wallet { get; set; } = string.Empty;
+
     public DateTimeOffset Datum { get; set; }
     public string Typ { get; set; } = string.Empty;
     public string Waehrung { get; set; } = string.Empty;

--- a/src/CryptoTracker.Client/Shared/Imports/BitpandaTransactionDTO.cs
+++ b/src/CryptoTracker.Client/Shared/Imports/BitpandaTransactionDTO.cs
@@ -1,7 +1,12 @@
+using System.Text.Json.Serialization;
+
 namespace CryptoTracker.Shared;
 
 public record BitpandaTransactionDTO
 {
+    public int WalletId { get; set; }
+    public string Wallet { get; set; } = string.Empty;
+
     public string TransactionId { get; set; } = string.Empty;
     public DateTimeOffset Timestamp { get; set; }
     public string TransactionType { get; set; } = string.Empty;

--- a/src/CryptoTracker.Client/Shared/Imports/MetamaskTradeDTO.cs
+++ b/src/CryptoTracker.Client/Shared/Imports/MetamaskTradeDTO.cs
@@ -1,7 +1,12 @@
+using System.Text.Json.Serialization;
+
 namespace CryptoTracker.Shared;
 
 public record MetamaskTradeDTO
 {
+    public int WalletId { get; set; }
+    public string Wallet { get; set; } = string.Empty;
+
     public DateTimeOffset Date { get; set; }
     public string Pair { get; set; } = string.Empty;
     public string Side { get; set; } = string.Empty;

--- a/src/CryptoTracker.Client/Shared/Imports/MetamaskTransactionDTO.cs
+++ b/src/CryptoTracker.Client/Shared/Imports/MetamaskTransactionDTO.cs
@@ -1,7 +1,12 @@
+using System.Text.Json.Serialization;
+
 namespace CryptoTracker.Shared;
 
 public record MetamaskTransactionDTO
 {
+    public int WalletId { get; set; }
+    public string Wallet { get; set; } = string.Empty;
+
     public DateTimeOffset Datum { get; set; }
     public string Typ { get; set; } = string.Empty;
     public string Coin { get; set; } = string.Empty;

--- a/src/CryptoTracker.Client/Shared/Imports/OkxDepositDTO.cs
+++ b/src/CryptoTracker.Client/Shared/Imports/OkxDepositDTO.cs
@@ -1,7 +1,12 @@
+using System.Text.Json.Serialization;
+
 namespace CryptoTracker.Shared;
 
 public record OkxDepositDTO
 {
+    public int WalletId { get; set; }
+    public string Wallet { get; set; } = string.Empty;
+
     public DateTimeOffset Date { get; set; }
     public string Coin { get; set; } = string.Empty;
     public string Network { get; set; } = string.Empty;

--- a/src/CryptoTracker.Client/Shared/Imports/OkxTradeDTO.cs
+++ b/src/CryptoTracker.Client/Shared/Imports/OkxTradeDTO.cs
@@ -1,7 +1,12 @@
+using System.Text.Json.Serialization;
+
 namespace CryptoTracker.Shared;
 
 public record OkxTradeDTO
 {
+    public int WalletId { get; set; }
+    public string Wallet { get; set; } = string.Empty;
+
     public DateTimeOffset Date { get; set; }
     public string Pair { get; set; } = string.Empty;
     public string Side { get; set; } = string.Empty;

--- a/src/CryptoTracker/Controllers/FlowController.cs
+++ b/src/CryptoTracker/Controllers/FlowController.cs
@@ -18,18 +18,18 @@ public class FlowController : ControllerBase, IFlowApi
     }
 
     [HttpGet("GetFlows")]
-    public async Task<IActionResult> GetFlows(string walletName, string symbolName)
+    public async Task<IActionResult> GetFlows(string walletName)
     {
-        var flows = await _flowService.GetFlows(walletName, symbolName);
+        var flows = await _flowService.GetFlows(walletName);
         var bilanz = FlowService.CalculateBilanz(flows);
 
         var response = new FlowsResponse { Flows = flows.Select(f => f.CloneToDTO()).ToList(), Bilanz = bilanz };
         return Ok(response);
     }
 
-    async Task<FlowsResponse?> IFlowApi.GetFlowsAsync(string walletName, string symbolName)
+    async Task<FlowsResponse?> IFlowApi.GetFlowsAsync(string walletName)
     {
-        var flows = await _flowService.GetFlows(walletName, symbolName);
+        var flows = await _flowService.GetFlows(walletName);
         var bilanz = FlowService.CalculateBilanz(flows);
         return new FlowsResponse
         {

--- a/src/CryptoTracker/Controllers/ImportEntriesController.cs
+++ b/src/CryptoTracker/Controllers/ImportEntriesController.cs
@@ -1,5 +1,6 @@
 using CryptoTracker.Entities.Import;
 using CryptoTracker.Shared;
+using CryptoTracker.Common;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using System.Text.Json;
@@ -28,15 +29,33 @@ public class ImportEntriesController : ControllerBase, IImportEntriesApi
     {
         return type switch
         {
-            ImportDocumentType.BinanceDepositHistory => await _dbContext.BinanceDeposits.ToListAsync(),
-            ImportDocumentType.BinanceWithdrawalHistory => await _dbContext.BinanceWithdrawals.ToListAsync(),
-            ImportDocumentType.BinanceTradingHistory => await _dbContext.BinanceTrades.ToListAsync(),
-            ImportDocumentType.BitcoinDeTransactions => await _dbContext.BitcoinDeTransactions.ToListAsync(),
-            ImportDocumentType.BitpandaTransaction => await _dbContext.BitpandaTransactions.ToListAsync(),
-            ImportDocumentType.MetamaskTradingHistory => await _dbContext.MetamaskTrades.ToListAsync(),
-            ImportDocumentType.MetamaskTransactions => await _dbContext.MetamaskTransactions.ToListAsync(),
-            ImportDocumentType.OkxDepositHistory => await _dbContext.OkxDeposits.ToListAsync(),
-            ImportDocumentType.OkxTradingHistory => await _dbContext.OkxTrades.ToListAsync(),
+            ImportDocumentType.BinanceDepositHistory =>
+                (await _dbContext.BinanceDeposits.Include(e => e.Wallet).ToListAsync())
+                    .Select(e => e.CloneToDTO<BinanceDepositDTO>()).ToList(),
+            ImportDocumentType.BinanceWithdrawalHistory =>
+                (await _dbContext.BinanceWithdrawals.Include(e => e.Wallet).ToListAsync())
+                    .Select(e => e.CloneToDTO<BinanceWithdrawalDTO>()).ToList(),
+            ImportDocumentType.BinanceTradingHistory =>
+                (await _dbContext.BinanceTrades.Include(e => e.Wallet).ToListAsync())
+                    .Select(e => e.CloneToDTO<BinanceTradeDTO>()).ToList(),
+            ImportDocumentType.BitcoinDeTransactions =>
+                (await _dbContext.BitcoinDeTransactions.Include(e => e.Wallet).ToListAsync())
+                    .Select(e => e.CloneToDTO<BitcoinDeTransactionDTO>()).ToList(),
+            ImportDocumentType.BitpandaTransaction =>
+                (await _dbContext.BitpandaTransactions.Include(e => e.Wallet).ToListAsync())
+                    .Select(e => e.CloneToDTO<BitpandaTransactionDTO>()).ToList(),
+            ImportDocumentType.MetamaskTradingHistory =>
+                (await _dbContext.MetamaskTrades.Include(e => e.Wallet).ToListAsync())
+                    .Select(e => e.CloneToDTO<MetamaskTradeDTO>()).ToList(),
+            ImportDocumentType.MetamaskTransactions =>
+                (await _dbContext.MetamaskTransactions.Include(e => e.Wallet).ToListAsync())
+                    .Select(e => e.CloneToDTO<MetamaskTransactionDTO>()).ToList(),
+            ImportDocumentType.OkxDepositHistory =>
+                (await _dbContext.OkxDeposits.Include(e => e.Wallet).ToListAsync())
+                    .Select(e => e.CloneToDTO<OkxDepositDTO>()).ToList(),
+            ImportDocumentType.OkxTradingHistory =>
+                (await _dbContext.OkxTrades.Include(e => e.Wallet).ToListAsync())
+                    .Select(e => e.CloneToDTO<OkxTradeDTO>()).ToList(),
             _ => new List<object>()
         };
     }

--- a/src/CryptoTracker/Services/FlowService.cs
+++ b/src/CryptoTracker/Services/FlowService.cs
@@ -13,16 +13,16 @@ public class FlowService
         _dbContext = dbContext;
     }
 
-    public async Task<IList<IFlow>> GetFlows(string walletName, string symbolName)
+    public async Task<IList<IFlow>> GetFlows(string walletName)
     {
         var trades = await _dbContext.CryptoTrades
             .Include(t => t.Wallet)
-            .Where(t => t.Wallet.Name == walletName && t.Symbol == symbolName)
+            .Where(t => t.Wallet.Name == walletName)
             .ToListAsync();
         var transactions = await _dbContext.CryptoTransactions
             .Include(t => t.Wallet)
             .Include(t => t.OppositeWallet)
-            .Where(t => t.Wallet.Name == walletName && t.Symbol == symbolName)
+            .Where(t => t.Wallet.Name == walletName)
             .ToListAsync();
 
         var flowList = trades.Cast<IFlow>().Concat(transactions).OrderBy(f => f.DateTime).ToList();


### PR DESCRIPTION
## Summary
- expose wallet name in import DTOs instead of mapping client-side
- convert import entities to DTOs with new extension method
- remove client reflection logic for assigning wallet names

## Testing
- `dotnet test`
